### PR TITLE
Initialize Swift package and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Generated/Client/Client.swift
+++ b/Generated/Client/Client.swift
@@ -1,0 +1,1 @@
+// Client SDK for Sample API

--- a/Generated/Models.swift
+++ b/Generated/Models.swift
@@ -1,0 +1,1 @@
+// Models for Sample API

--- a/Generated/Server/Server.swift
+++ b/Generated/Server/Server.swift
@@ -1,0 +1,1 @@
+// Server kernel for Sample API

--- a/OpenAPI/api.yaml
+++ b/OpenAPI/api.yaml
@@ -1,0 +1,3 @@
+{
+  "title": "Sample API"
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "SwiftCodexOpenAPIKernel",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(name: "generator", targets: ["Generator"]),
+    ],
+    targets: [
+        .target(name: "Parser"),
+        .target(name: "ModelEmitter"),
+        .target(name: "ClientGenerator"),
+        .target(name: "ServerGenerator"),
+        .executableTarget(
+            name: "Generator",
+            dependencies: ["Parser", "ModelEmitter", "ClientGenerator", "ServerGenerator"]
+        ),
+        .testTarget(name: "GeneratorTests", dependencies: ["Generator"]),
+        .testTarget(name: "ServerTests", dependencies: ["ServerGenerator"])
+    ]
+)

--- a/Sources/ClientGenerator/ClientGenerator.swift
+++ b/Sources/ClientGenerator/ClientGenerator.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Parser
+
+public enum ClientGenerator {
+    public static func emitClient(from spec: OpenAPISpec, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        let output = "// Client SDK for \(spec.title)\n"
+        try output.write(to: url.appendingPathComponent("Client.swift"), atomically: true, encoding: .utf8)
+    }
+}

--- a/Sources/Generator/main.swift
+++ b/Sources/Generator/main.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Parser
+import ModelEmitter
+import ClientGenerator
+import ServerGenerator
+
+@main
+struct GeneratorCLI {
+    static func main() throws {
+        var inputPath: String?
+        var outputPath: String?
+        var iterator = CommandLine.arguments.dropFirst().makeIterator()
+        while let arg = iterator.next() {
+            switch arg {
+            case "--input": inputPath = iterator.next()
+            case "--output": outputPath = iterator.next()
+            default: break
+            }
+        }
+        guard let inputPath, let outputPath else {
+            print("Usage: generator --input <spec> --output <dir>")
+            return
+        }
+        let specURL = URL(fileURLWithPath: inputPath)
+        let outURL = URL(fileURLWithPath: outputPath)
+        let spec = try SpecLoader.load(from: specURL)
+        try FileManager.default.createDirectory(at: outURL, withIntermediateDirectories: true)
+        try ModelEmitter.emit(from: spec, to: outURL)
+        try ClientGenerator.emitClient(from: spec, to: outURL.appendingPathComponent("Client"))
+        try ServerGenerator.emitServer(from: spec, to: outURL.appendingPathComponent("Server"))
+    }
+}

--- a/Sources/ModelEmitter/ModelEmitter.swift
+++ b/Sources/ModelEmitter/ModelEmitter.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Parser
+
+public enum ModelEmitter {
+    public static func emit(from spec: OpenAPISpec, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        let output = "// Models for \(spec.title)\n"
+        try output.write(to: url.appendingPathComponent("Models.swift"), atomically: true, encoding: .utf8)
+    }
+}

--- a/Sources/Parser/SpecLoader.swift
+++ b/Sources/Parser/SpecLoader.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public struct OpenAPISpec: Codable {
+    public let title: String
+}
+
+public enum SpecLoader {
+    public static func load(from url: URL) throws -> OpenAPISpec {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(OpenAPISpec.self, from: data)
+    }
+}

--- a/Sources/ServerGenerator/ServerGenerator.swift
+++ b/Sources/ServerGenerator/ServerGenerator.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Parser
+
+public enum ServerGenerator {
+    public static func emitServer(from spec: OpenAPISpec, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        let output = "// Server kernel for \(spec.title)\n"
+        try output.write(to: url.appendingPathComponent("Server.swift"), atomically: true, encoding: .utf8)
+    }
+}

--- a/Tests/GeneratorTests/GeneratorTests.swift
+++ b/Tests/GeneratorTests/GeneratorTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import Generator
+
+final class GeneratorTests: XCTestCase {
+    func testCLIParsesArguments() throws {
+        // Placeholder test
+        XCTAssertTrue(true)
+    }
+}

--- a/Tests/ServerTests/ServerTests.swift
+++ b/Tests/ServerTests/ServerTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import ServerGenerator
+
+final class ServerTests: XCTestCase {
+    func testServerPlaceholder() throws {
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Swift package and add `Package.swift`
- create Parser, ModelEmitter, ClientGenerator, ServerGenerator modules
- implement CLI tool in `Sources/Generator/main.swift`
- add placeholder tests for generator and server
- add a sample OpenAPI spec and generated outputs

## Testing
- `swift test`
- `swift run generator --input OpenAPI/api.yaml --output Generated`

------
https://chatgpt.com/codex/tasks/task_e_686b4c37e5988325a664c30e37abeca6