### PR TITLE
Implement CLI fixture tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,11 @@ let package = Package(
             name: "Generator",
             dependencies: ["Parser", "ModelEmitter", "ClientGenerator", "ServerGenerator"]
         ),
-        .testTarget(name: "GeneratorTests", dependencies: ["Generator"]),
+        .testTarget(
+            name: "GeneratorTests",
+            dependencies: ["Generator"],
+            resources: [.process("Fixtures")]
+        ),
         .testTarget(name: "ServerTests", dependencies: ["ServerGenerator"]),
         .testTarget(name: "ParserTests", dependencies: ["Parser"]),
         .testTarget(name: "ClientGeneratorTests", dependencies: ["ClientGenerator", "Parser"]),

--- a/Sources/Generator/main.swift
+++ b/Sources/Generator/main.swift
@@ -6,10 +6,10 @@ import ServerGenerator
 
 @main
 struct GeneratorCLI {
-    static func main() throws {
+    static func run(args: [String]) throws {
         var inputPath: String?
         var outputPath: String?
-        var iterator = CommandLine.arguments.dropFirst().makeIterator()
+        var iterator = args.makeIterator()
         while let arg = iterator.next() {
             switch arg {
             case "--input": inputPath = iterator.next()
@@ -28,5 +28,9 @@ struct GeneratorCLI {
         try ModelEmitter.emit(from: spec, to: outURL)
         try ClientGenerator.emitClient(from: spec, to: outURL.appendingPathComponent("Client"))
         try ServerGenerator.emitServer(from: spec, to: outURL.appendingPathComponent("Server"))
+    }
+
+    static func main() throws {
+        try run(args: Array(CommandLine.arguments.dropFirst()))
     }
 }

--- a/Tests/GeneratorTests/Fixtures/Generated/Client/APIClient.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Client/APIClient.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}

--- a/Tests/GeneratorTests/Fixtures/Generated/Client/APIRequest.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Client/APIRequest.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol APIRequest {
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+}

--- a/Tests/GeneratorTests/Fixtures/Generated/Client/ClientModels.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Client/ClientModels.swift
@@ -1,0 +1,7 @@
+// Models for Sample API
+
+public struct Todo: Codable {
+    public let id: Int
+    public let name: String
+}
+

--- a/Tests/GeneratorTests/Fixtures/Generated/Client/Requests/GetTodos.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Client/Requests/GetTodos.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct GetTodos: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/todos" }
+}

--- a/Tests/GeneratorTests/Fixtures/Generated/RootModels.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/RootModels.swift
@@ -1,0 +1,7 @@
+// Models for Sample API
+
+public struct Todo: Codable {
+    public let id: Int
+    public let name: String
+}
+

--- a/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPKernel.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPKernel.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct HTTPKernel {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        try await router.route(request)
+    }
+}

--- a/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPRequest.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPRequest.swift
@@ -1,0 +1,4 @@
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+}

--- a/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPResponse.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPResponse.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct HTTPResponse {
+    public var status: Int
+    public var body: Data
+
+    public init(status: Int = 200, body: Data = Data()) {
+        self.status = status
+        self.body = body
+    }
+}

--- a/Tests/GeneratorTests/Fixtures/Generated/Server/Handlers.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Server/Handlers.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public struct Handlers {
+    public init() {}
+    public func gettodos(_ request: HTTPRequest) async throws -> HTTPResponse {
+        return HTTPResponse()
+    }
+}

--- a/Tests/GeneratorTests/Fixtures/Generated/Server/Router.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Server/Router.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        switch (request.method, request.path) {
+        case ("GET", "/todos"):
+            return try await handlers.gettodos(request)
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}

--- a/Tests/GeneratorTests/Fixtures/Generated/Server/ServerModels.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Server/ServerModels.swift
@@ -1,0 +1,7 @@
+// Models for Sample API
+
+public struct Todo: Codable {
+    public let id: Int
+    public let name: String
+}
+

--- a/Tests/GeneratorTests/Fixtures/api.json
+++ b/Tests/GeneratorTests/Fixtures/api.json
@@ -1,0 +1,19 @@
+{
+  "title": "Sample API",
+  "components": {
+    "schemas": {
+      "Todo": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/todos": {
+      "get": { "operationId": "GetTodos" }
+    }
+  }
+}

--- a/Tests/GeneratorTests/GeneratorTests.swift
+++ b/Tests/GeneratorTests/GeneratorTests.swift
@@ -2,8 +2,37 @@ import XCTest
 @testable import Generator
 
 final class GeneratorTests: XCTestCase {
-    func testCLIParsesArguments() throws {
-        // Placeholder test
-        XCTAssertTrue(true)
+    func testCLIWithFixtures() throws {
+        let fixturesDir = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+        let specURL = fixturesDir.appendingPathComponent("api.json")
+        let outDir = FileManager.default.temporaryDirectory.appendingPathComponent("cli-test")
+        try? FileManager.default.removeItem(at: outDir)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+
+        try GeneratorCLI.run(args: ["--input", specURL.path, "--output", outDir.path])
+
+        func assertFile(_ relative: String, fixtureName: String? = nil) throws {
+            let generatedURL = outDir.appendingPathComponent(relative)
+            let fixtureURL = fixturesDir
+                .appendingPathComponent("Generated")
+                .appendingPathComponent(fixtureName ?? relative)
+            let generated = try String(contentsOf: generatedURL)
+            let expected = try String(contentsOf: fixtureURL)
+            XCTAssertEqual(generated, expected, "Mismatch for \(relative)")
+        }
+
+        try assertFile("Models.swift", fixtureName: "RootModels.swift")
+        try assertFile("Client/APIRequest.swift")
+        try assertFile("Client/APIClient.swift")
+        try assertFile("Client/Models.swift", fixtureName: "Client/ClientModels.swift")
+        try assertFile("Client/Requests/GetTodos.swift")
+        try assertFile("Server/HTTPRequest.swift")
+        try assertFile("Server/HTTPResponse.swift")
+        try assertFile("Server/Handlers.swift")
+        try assertFile("Server/Router.swift")
+        try assertFile("Server/HTTPKernel.swift")
+        try assertFile("Server/Models.swift", fixtureName: "Server/ServerModels.swift")
     }
 }

--- a/codex-plan.md
+++ b/codex-plan.md
@@ -57,7 +57,7 @@ This plan defines how Codex should build a Swift 6-native OpenAPI code generator
 ## 🧪 Phase 6 · Testing & Validation
 
  - [x] Add `XCTestCase` tests for model parsing.
-- [ ] Test the CLI with fixtures.
+ - [x] Test the CLI with fixtures.
 - [ ] Simulate HTTP requests directly to router/kernel in unit tests.
 
 ---


### PR DESCRIPTION
## Summary
- add a `run(args:)` helper to the CLI so tests can invoke it
- add fixture spec and generated outputs
- implement `GeneratorTests.testCLIWithFixtures`
- update `codex-plan.md` to mark CLI test complete

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_686b65c6b6f4832597146780b4418e74