### PR TITLE
Add YAML decoding to SpecLoader

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,11 @@ let package = Package(
     products: [
         .executable(name: "generator", targets: ["Generator"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0")
+    ],
     targets: [
-        .target(name: "Parser"),
+        .target(name: "Parser", dependencies: ["Yams"]),
         .target(name: "ModelEmitter", dependencies: ["Parser"]),
         .target(name: "ClientGenerator", dependencies: ["Parser"]),
         .target(name: "ServerGenerator", dependencies: ["Parser"]),

--- a/Sources/Parser/SpecLoader.swift
+++ b/Sources/Parser/SpecLoader.swift
@@ -1,10 +1,24 @@
 import Foundation
+import Yams
 
 
 public enum SpecLoader {
     public static func load(from url: URL) throws -> OpenAPISpec {
         let data = try Data(contentsOf: url)
-        let spec = try JSONDecoder().decode(OpenAPISpec.self, from: data)
+
+        // Attempt JSON decoding first
+        if let spec = try? JSONDecoder().decode(OpenAPISpec.self, from: data) {
+            try SpecValidator.validate(spec)
+            return spec
+        }
+
+        // Fallback to YAML decoding
+        guard let yamlString = String(data: data, encoding: .utf8) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Input data is not valid UTF-8"))
+        }
+        let yamlObject = try Yams.load(yaml: yamlString)
+        let jsonData = try JSONSerialization.data(withJSONObject: yamlObject, options: [])
+        let spec = try JSONDecoder().decode(OpenAPISpec.self, from: jsonData)
         try SpecValidator.validate(spec)
         return spec
     }

--- a/Tests/ParserTests/ParserTests.swift
+++ b/Tests/ParserTests/ParserTests.swift
@@ -12,6 +12,16 @@ final class ParserTests: XCTestCase {
         XCTAssertEqual(spec.title, "My API")
     }
 
+    func testSpecLoaderParsesYAMLTitle() throws {
+        let yaml = "title: My API"
+        let tmpDir = FileManager.default.temporaryDirectory
+        let fileURL = tmpDir.appendingPathComponent("spec.yaml")
+        try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let spec = try SpecLoader.load(from: fileURL)
+        XCTAssertEqual(spec.title, "My API")
+    }
+
     func testSpecValidationRejectsEmptyTitle() throws {
         let spec = OpenAPISpec(title: "")
         XCTAssertThrowsError(try SpecValidator.validate(spec)) { error in


### PR DESCRIPTION
## Summary
- allow `SpecLoader` to parse YAML via Yams
- add Yams dependency in Package.swift
- test YAML parsing alongside JSON

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_686b75ed0b0c8325a61f236f7670b6a1