### PR TITLE
Complete server generator output and add regeneration script

### DIFF
--- a/Generated/Client/Client.swift
+++ b/Generated/Client/Client.swift
@@ -1,1 +1,0 @@
-// Client SDK for Sample API

--- a/Generated/Server/HTTPKernel.swift
+++ b/Generated/Server/HTTPKernel.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct HTTPKernel {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        try await router.route(request)
+    }
+}

--- a/Generated/Server/HTTPRequest.swift
+++ b/Generated/Server/HTTPRequest.swift
@@ -1,0 +1,4 @@
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+}

--- a/Generated/Server/HTTPResponse.swift
+++ b/Generated/Server/HTTPResponse.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct HTTPResponse {
+    public var status: Int
+    public var body: Data
+
+    public init(status: Int = 200, body: Data = Data()) {
+        self.status = status
+        self.body = body
+    }
+}

--- a/Generated/Server/Handlers.swift
+++ b/Generated/Server/Handlers.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public struct Handlers {
+    public init() {}
+    public func gettodos(_ request: HTTPRequest) async throws -> HTTPResponse {
+        return HTTPResponse()
+    }
+}

--- a/Generated/Server/Router.swift
+++ b/Generated/Server/Router.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        switch (request.method, request.path) {
+        case ("GET", "/todos"):
+            return try await handlers.gettodos(request)
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}

--- a/Generated/Server/Server.swift
+++ b/Generated/Server/Server.swift
@@ -1,1 +1,0 @@
-// Server kernel for Sample API

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ swift-codex-openapi-kernel/
 
 ```bash
 swift build -c release
-swift run generator --input OpenAPI/api.yaml --output Generated/
+./regenerate.sh
 swift test
 ```
 

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remove previous generated output
+rm -rf Generated/Client Generated/Server
+
+# Regenerate client and server code from the OpenAPI spec
+swift run generator --input OpenAPI/api.yaml --output Generated


### PR DESCRIPTION
## Summary
- generate full server output using the generator
- remove obsolete placeholder files
- add `regenerate.sh` script for rebuilding generated code
- document the new regeneration step in the README

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_686b773fed108325b9ed8064b60e4a4c