### PR TITLE
Add OpenAPI service catalog and per-service generation docs

### DIFF
--- a/FountainAi/openAPI/README.md
+++ b/FountainAi/openAPI/README.md
@@ -1,0 +1,20 @@
+# FountainAI Service Catalog
+
+This directory contains the OpenAPI specifications for each FountainAI microservice. Each YAML file defines the API surface and server entrypoint for that service.
+
+| Service | Entrypoint | Description | Spec |
+| --- | --- | --- | --- |
+| Baseline Awareness | http://awareness.fountain.coach/api/v1 | Manages baselines, drift, patterns, reflection data and semantic analytics. | [baseline-awareness.yml](baseline-awareness.yml) |
+| Bootstrap | http://bootstrap.fountain.coach/api/v1 | Initializes corpora, seeds GPT roles and adds baseline snapshots. Relies on the Awareness API to store initial artifacts. | [bootstrap.yml](bootstrap.yml) |
+| Function Caller | http://functions.fountain.coach/api/v1 | Maps OpenAI function-calling plans to HTTP operations. Retrieves definitions from the Tools Factory. | [function-caller.yml](function-caller.yml) |
+| LLM Gateway | http://llm-gateway.fountain.coach/api/v1 | Proxies requests to any LLM with function-calling support. Used by the Planner for LLM-driven tasks. | [llm-gateway.yml](llm-gateway.yml) |
+| Persistence | http://persist.fountain.coach/api/v1 | Typesense-backed store for baselines, drifts, reflections and registered tools. | [persist.yml](persist.yml) |
+| Planner | http://planner.fountain.coach/api/v1 | Orchestrates planning workflows across the LLM Gateway and Function Caller. | [planner.yml](planner.yml) |
+| Tools Factory | http://tools-factory.fountain.coach/api/v1 | Registers new tool definitions in the shared Typesense collection consumed by the Function Caller. | [tools-factory.yml](tools-factory.yml) |
+
+### Cross-service Interactions
+
+- **Bootstrap → Awareness**: bootstrap operations seed corpora and baseline snapshots by calling the Awareness API.
+- **Tools Factory → Function Caller**: the Tools Factory persists function definitions that the Function Caller dynamically invokes.
+- **Planner → LLM Gateway & Function Caller**: the Planner coordinates with the LLM Gateway for language model responses and triggers registered functions through the Function Caller.
+

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This repository implements a complete code generation workflow that:
 ```
 swift-codex-openapi-kernel/
 ├── FountainAi/openAPI/           ← Service specs in OpenAPI 3.1 format
+│   └── README.md                 ← Catalog of services and entrypoints
 ├── Sources/
 │   └── Generator/                ← CLI tool source
 ├── Generated/
@@ -64,7 +65,14 @@ swift-codex-openapi-kernel/
    This command reads every `*.yml` spec under `FountainAi/openAPI/` and
    emits a dedicated client and server for each service under
    `Generated/Client/<Service>/` and `Generated/Server/<Service>/`.
-3. **Run the test suite**
+3. **Generate code for a single service**
+   ```bash
+   swift run generator --input FountainAi/openAPI/bootstrap.yml --output Generated/tmp
+   cp -r Generated/tmp/Client/. Generated/Client/bootstrap/
+   cp -r Generated/tmp/Server/. Generated/Server/bootstrap/
+   ```
+   Replace `bootstrap.yml` with another spec to target a different service.
+4. **Run the test suite**
    ```bash
    swift test
    ```
@@ -73,6 +81,12 @@ swift-codex-openapi-kernel/
 
 Add or modify any service spec under `FountainAi/openAPI/`. Re-run
 `./regenerate.sh` whenever a spec changes to regenerate the Swift sources.
+
+### Troubleshooting
+
+- **Parser errors** – ensure each YAML file is valid OpenAPI 3.1. The generator prints the failing file path on error.
+- **Missing Swift toolchain** – install dependencies with `sudo apt-get update && sudo apt-get install -y clang libicu-dev swift`.
+- **Build failures** – run `swift build -v` to see compilation output and verify you generated sources for the intended service.
 
 ---
 


### PR DESCRIPTION
## Summary
- create `FountainAi/openAPI/README.md` cataloging available services and their entrypoints
- mention the catalog in the repository structure
- document how to generate code for an individual service
- add troubleshooting tips for build and parsing issues

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_686b8ca08fe88325ad6fc376c40657f1