### PR TITLE
Expand OpenAPI parser

### DIFF
--- a/Sources/Parser/OpenAPISpec.swift
+++ b/Sources/Parser/OpenAPISpec.swift
@@ -1,28 +1,79 @@
 import Foundation
 
 public struct OpenAPISpec: Codable {
+    /// Components container supporting only schemas for now.
     public struct Components: Codable {
         public var schemas: [String: Schema]
     }
 
-    public struct Operation: Codable {
-        public var operationId: String
+    /// Basic JSON Schema representation used throughout the spec.
+    public struct Schema: Codable {
+        public struct Property: Codable {
+            public var ref: String?
+            public var type: String?
+
+            enum CodingKeys: String, CodingKey {
+                case ref = "$ref"
+                case type
+            }
+        }
+
+        public var ref: String?
+        public var type: String?
+        public var properties: [String: Property]?
+
+        enum CodingKeys: String, CodingKey {
+            case ref = "$ref"
+            case type
+            case properties
+        }
     }
 
+    /// Parameter object representing path or query parameters.
+    public struct Parameter: Codable {
+        public var name: String
+        public var location: String
+        public var required: Bool?
+        public var schema: Schema?
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case location = "in"
+            case required
+            case schema
+        }
+    }
+
+    /// Media type containing a schema.
+    public struct MediaType: Codable {
+        public var schema: Schema?
+    }
+
+    /// Request body container.
+    public struct RequestBody: Codable {
+        public var content: [String: MediaType]
+    }
+
+    /// Response object keyed by status code.
+    public struct Response: Codable {
+        public var description: String?
+        public var content: [String: MediaType]?
+    }
+
+    /// Operation including parameters, request body and responses.
+    public struct Operation: Codable {
+        public var operationId: String
+        public var parameters: [Parameter]?
+        public var requestBody: RequestBody?
+        public var responses: [String: Response]?
+    }
+
+    /// Path item grouping multiple HTTP methods.
     public struct PathItem: Codable {
         public var get: Operation?
         public var post: Operation?
         public var put: Operation?
         public var delete: Operation?
-    }
-
-    public struct Schema: Codable {
-        public struct Property: Codable {
-            public var type: String?
-        }
-
-        public var type: String?
-        public var properties: [String: Property]?
     }
 
     public let title: String
@@ -32,6 +83,9 @@ public struct OpenAPISpec: Codable {
 
 extension OpenAPISpec.Schema.Property {
     public var swiftType: String {
+        if let ref {
+            return ref.components(separatedBy: "/").last ?? ref
+        }
         guard let type else { return "String" }
         switch type {
         case "string": return "String"

--- a/Sources/Parser/SpecValidator.swift
+++ b/Sources/Parser/SpecValidator.swift
@@ -14,5 +14,76 @@ public enum SpecValidator {
         if spec.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             throw ValidationError("title cannot be empty")
         }
+
+        func validateSchema(_ schema: OpenAPISpec.Schema) throws {
+            if let ref = schema.ref {
+                let name = ref.components(separatedBy: "/").last ?? ref
+                if spec.components?.schemas[name] == nil {
+                    throw ValidationError("unresolved reference \(ref)")
+                }
+            }
+            if let properties = schema.properties {
+                for property in properties.values {
+                    if let ref = property.ref {
+                        let name = ref.components(separatedBy: "/").last ?? ref
+                        if spec.components?.schemas[name] == nil {
+                            throw ValidationError("unresolved reference \(ref)")
+                        }
+                    }
+                }
+            }
+        }
+
+        if let components = spec.components {
+            for schema in components.schemas.values {
+                try validateSchema(schema)
+            }
+        }
+
+        if let paths = spec.paths {
+            for (path, item) in paths {
+                let operations = [item.get, item.post, item.put, item.delete].compactMap { $0 }
+                for op in operations {
+                    if op.operationId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        throw ValidationError("operationId cannot be empty for \(path)")
+                    }
+
+                    for param in op.parameters ?? [] {
+                        if param.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            throw ValidationError("parameter name cannot be empty in \(op.operationId)")
+                        }
+                        if param.location.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            throw ValidationError("parameter location cannot be empty in \(param.name)")
+                        }
+                        if param.location == "path" && param.required != true {
+                            throw ValidationError("path parameter \(param.name) must be required")
+                        }
+                        if let schema = param.schema {
+                            try validateSchema(schema)
+                        }
+                    }
+
+                    if let body = op.requestBody {
+                        for media in body.content.values {
+                            if let schema = media.schema {
+                                try validateSchema(schema)
+                            }
+                        }
+                    }
+
+                    if let responses = op.responses {
+                        for response in responses.values {
+                            if let content = response.content {
+                                for media in content.values {
+                                    if let schema = media.schema {
+                                        try validateSchema(schema)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/Tests/ParserTests/ParserTests.swift
+++ b/Tests/ParserTests/ParserTests.swift
@@ -46,4 +46,64 @@ final class ParserTests: XCTestCase {
             XCTAssertEqual(validationError, SpecValidator.ValidationError("title cannot be empty"))
         }
     }
+
+    func testOperationParsesParametersAndResponses() throws {
+        let json = """
+        {
+          "title": "API",
+          "components": {
+            "schemas": {
+              "Todo": {"type": "object"}
+            }
+          },
+          "paths": {
+            "/todos/{id}": {
+              "get": {
+                "operationId": "get_todo",
+                "parameters": [
+                  {"name": "id", "in": "path", "required": true, "schema": {"type": "string"}},
+                  {"name": "verbose", "in": "query", "schema": {"type": "boolean"}}
+                ],
+                "responses": {
+                  "200": {
+                    "description": "ok",
+                    "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Todo"}}}
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("spec.json")
+        try json.write(to: tmp, atomically: true, encoding: .utf8)
+        let spec = try SpecLoader.load(from: tmp)
+        let op = spec.paths?["/todos/{id}"]?.get
+        XCTAssertEqual(op?.parameters?.count, 2)
+        XCTAssertEqual(op?.responses?["200"]?.content?["application/json"]?.schema?.ref, "#/components/schemas/Todo")
+    }
+
+    func testValidationRejectsUnresolvedReference() throws {
+        let json = """
+        {
+          "title": "Bad API",
+          "paths": {
+            "/items": {
+              "get": {
+                "operationId": "list",
+                "responses": {"200": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Missing"}}}}}
+              }
+            }
+          }
+        }
+        """
+
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("bad.json")
+        try json.write(to: tmp, atomically: true, encoding: .utf8)
+        XCTAssertThrowsError(try SpecLoader.load(from: tmp)) { error in
+            guard let validationError = error as? SpecValidator.ValidationError else { return XCTFail("wrong error") }
+            XCTAssertEqual(validationError, SpecValidator.ValidationError("unresolved reference #/components/schemas/Missing"))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add parameter, request body and response types to `OpenAPISpec`
- allow schema references and expose `$ref`
- validate required fields and reference resolution
- extend parser tests for parameters and responses

## Testing
- `swift build`
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_686ba621530883258c978ab9f55ef198