### PR TITLE
Enhance model emission

### DIFF
--- a/Sources/ModelEmitter/ModelEmitter.swift
+++ b/Sources/ModelEmitter/ModelEmitter.swift
@@ -7,16 +7,54 @@ public enum ModelEmitter {
 
         var output = "// Models for \(spec.title)\n\n"
 
-        if let schemas = spec.components?.schemas {
-            for (name, schema) in schemas.sorted(by: { $0.key < $1.key }) {
-                guard schema.type == "object", let properties = schema.properties else { continue }
+        func appendSchema(_ name: String, _ schema: OpenAPISpec.Schema) {
+            if let enumValues = schema.enumValues, schema.type == "string" {
+                output += "public enum \(name): String, Codable {\n"
+                for value in enumValues {
+                    output += "    case \(value)\n"
+                }
+                output += "}\n\n"
+                return
+            }
+
+            if schema.type == "object", let properties = schema.properties {
                 output += "public struct \(name): Codable {\n"
-                for propName in properties.keys.sorted() {
-                    if let property = properties[propName] {
-                        output += "    public let \(propName): \(property.swiftType)\n"
+                for prop in properties.keys.sorted() {
+                    if let property = properties[prop] {
+                        output += "    public let \(prop): \(property.swiftType)\n"
                     }
                 }
                 output += "}\n\n"
+                return
+            }
+
+            if schema.type == "array", let items = schema.items {
+                output += "public typealias \(name) = [\(items.swiftType)]\n\n"
+                return
+            }
+
+            if let type = schema.type {
+                output += "public typealias \(name) = \(schema.swiftType)\n\n"
+            }
+        }
+
+        if let schemas = spec.components?.schemas {
+            for (name, schema) in schemas.sorted(by: { $0.key < $1.key }) {
+                appendSchema(name, schema)
+            }
+        }
+
+        if let paths = spec.paths {
+            for (_, item) in paths {
+                let ops = [item.get, item.post, item.put, item.delete].compactMap { $0 }
+                for op in ops {
+                    if let reqSchema = op.requestBody?.content["application/json"]?.schema, reqSchema.ref == nil {
+                        appendSchema("\(op.operationId)Request", reqSchema)
+                    }
+                    if let respSchema = op.responses?["200"]?.content?["application/json"]?.schema, respSchema.ref == nil {
+                        appendSchema("\(op.operationId)Response", respSchema)
+                    }
+                }
             }
         }
 
@@ -29,5 +67,26 @@ public enum ModelEmitter {
         let serverDir = url.appendingPathComponent("Server")
         try FileManager.default.createDirectory(at: serverDir, withIntermediateDirectories: true)
         try output.write(to: serverDir.appendingPathComponent("Models.swift"), atomically: true, encoding: .utf8)
+
+        let packageDir = url.appendingPathComponent("SharedModels")
+        let sourcesDir = packageDir.appendingPathComponent("Sources/SharedModels")
+        try FileManager.default.createDirectory(at: sourcesDir, withIntermediateDirectories: true)
+        try output.write(to: sourcesDir.appendingPathComponent("Models.swift"), atomically: true, encoding: .utf8)
+
+        let packageSwift = """
+        // swift-tools-version: 6.1
+        import PackageDescription
+
+        let package = Package(
+            name: \"SharedModels\",
+            products: [
+                .library(name: \"SharedModels\", targets: [\"SharedModels\"])
+            ],
+            targets: [
+                .target(name: \"SharedModels\")
+            ]
+        )
+        """
+        try packageSwift.write(to: packageDir.appendingPathComponent("Package.swift"), atomically: true, encoding: .utf8)
     }
 }

--- a/Sources/Parser/OpenAPISpec.swift
+++ b/Sources/Parser/OpenAPISpec.swift
@@ -7,25 +7,33 @@ public struct OpenAPISpec: Codable {
     }
 
     /// Basic JSON Schema representation used throughout the spec.
-    public struct Schema: Codable {
-        public struct Property: Codable {
+    public final class Schema: Codable {
+        public final class Property: Codable {
             public var ref: String?
             public var type: String?
+            public var enumValues: [String]?
+            public var items: Schema?
 
             enum CodingKeys: String, CodingKey {
                 case ref = "$ref"
                 case type
+                case enumValues = "enum"
+                case items
             }
         }
 
         public var ref: String?
         public var type: String?
         public var properties: [String: Property]?
+        public var enumValues: [String]?
+        public var items: Schema?
 
         enum CodingKeys: String, CodingKey {
             case ref = "$ref"
             case type
             case properties
+            case enumValues = "enum"
+            case items
         }
     }
 
@@ -91,6 +99,33 @@ extension OpenAPISpec.Schema.Property {
         case "string": return "String"
         case "integer": return "Int"
         case "boolean": return "Bool"
+        case "array":
+            if let itemType = items?.swiftType {
+                return "[\(itemType)]"
+            } else {
+                return "[String]"
+            }
+        default: return "String"
+        }
+    }
+}
+
+extension OpenAPISpec.Schema {
+    public var swiftType: String {
+        if let ref {
+            return ref.components(separatedBy: "/").last ?? ref
+        }
+        guard let type else { return "String" }
+        switch type {
+        case "string": return "String"
+        case "integer": return "Int"
+        case "boolean": return "Bool"
+        case "array":
+            if let itemType = items?.swiftType {
+                return "[\(itemType)]"
+            } else {
+                return "[String]"
+            }
         default: return "String"
         }
     }

--- a/Tests/ModelEmitterTests/ModelEmitterTests.swift
+++ b/Tests/ModelEmitterTests/ModelEmitterTests.swift
@@ -36,6 +36,9 @@ final class ModelEmitterTests: XCTestCase {
         let expected = try String(contentsOf: fixtureURL)
 
         XCTAssertEqual(generated, expected)
+
+        let sharedURL = outDir.appendingPathComponent("SharedModels/Sources/SharedModels/Models.swift")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sharedURL.path))
     }
 }
 


### PR DESCRIPTION
## Summary
- support enum and array schemas in `OpenAPISpec`
- generate request and response body models
- emit a SharedModels Swift package for reuse
- test for presence of the new shared models
- fix recursive schema storage by switching `Schema` to a class

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_686ba8c6e6d88325b5fcbbed9d6732da