### PR TITLE
Upgrade client generator for typed requests

### DIFF
--- a/Sources/ClientGenerator/ClientGenerator.swift
+++ b/Sources/ClientGenerator/ClientGenerator.swift
@@ -8,10 +8,15 @@ public enum ClientGenerator {
         let apiRequest = """
         import Foundation
 
+        /// Empty body type used for requests without a payload.
+        public struct NoBody: Codable {}
+
         public protocol APIRequest {
+            associatedtype Body: Encodable = NoBody
             associatedtype Response: Decodable
             var method: String { get }
             var path: String { get }
+            var body: Body? { get }
         }
         """
         try (apiRequest + "\n").write(to: url.appendingPathComponent("APIRequest.swift"), atomically: true, encoding: .utf8)
@@ -28,17 +33,32 @@ public enum ClientGenerator {
         public struct APIClient {
             let baseURL: URL
             let session: HTTPSession
+            let defaultHeaders: [String: String]
 
-            public init(baseURL: URL, session: HTTPSession = URLSession.shared) {
+            public init(baseURL: URL, session: HTTPSession = URLSession.shared, defaultHeaders: [String: String] = [:]) {
                 self.baseURL = baseURL
                 self.session = session
+                self.defaultHeaders = defaultHeaders
             }
 
             public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
                 var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
                 urlRequest.httpMethod = request.method
+                for (header, value) in defaultHeaders {
+                    urlRequest.setValue(value, forHTTPHeaderField: header)
+                }
+                if let body = request.body {
+                    urlRequest.httpBody = try JSONEncoder().encode(body)
+                    urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                }
                 let (data, _) = try await session.data(for: urlRequest)
                 return try JSONDecoder().decode(R.Response.self, from: data)
+            }
+        }
+
+        public extension APIClient {
+            init(baseURL: URL, bearerToken: String, session: HTTPSession = URLSession.shared) {
+                self.init(baseURL: baseURL, session: session, defaultHeaders: ["Authorization": "Bearer \\(bearerToken)"])
             }
         }
         """
@@ -50,31 +70,59 @@ public enum ClientGenerator {
         if let paths = spec.paths {
             for (path, item) in paths {
                 if let op = item.get {
-                    try emitRequest(named: op.operationId, method: "GET", path: path, in: requestsDir)
+                    try emitRequest(operation: op, method: "GET", path: path, in: requestsDir)
                 }
                 if let op = item.post {
-                    try emitRequest(named: op.operationId, method: "POST", path: path, in: requestsDir)
+                    try emitRequest(operation: op, method: "POST", path: path, in: requestsDir)
                 }
                 if let op = item.put {
-                    try emitRequest(named: op.operationId, method: "PUT", path: path, in: requestsDir)
+                    try emitRequest(operation: op, method: "PUT", path: path, in: requestsDir)
                 }
                 if let op = item.delete {
-                    try emitRequest(named: op.operationId, method: "DELETE", path: path, in: requestsDir)
+                    try emitRequest(operation: op, method: "DELETE", path: path, in: requestsDir)
                 }
             }
         }
     }
 
-    private static func emitRequest(named name: String, method: String, path: String, in dir: URL) throws {
+    private static func bodyType(for op: OpenAPISpec.Operation) -> String {
+        guard let schema = op.requestBody?.content["application/json"]?.schema else {
+            return "NoBody"
+        }
+        if schema.ref == nil {
+            return "\(op.operationId)Request"
+        }
+        return schema.swiftType
+    }
+
+    private static func responseType(for op: OpenAPISpec.Operation) -> String {
+        guard let schema = op.responses?["200"]?.content?["application/json"]?.schema else {
+            return "Data"
+        }
+        if schema.ref == nil {
+            return "\(op.operationId)Response"
+        }
+        return schema.swiftType
+    }
+
+    private static func emitRequest(operation op: OpenAPISpec.Operation, method: String, path: String, in dir: URL) throws {
+        let bodyType = bodyType(for: op)
+        let responseType = responseType(for: op)
         let output = """
         import Foundation
 
-        public struct \(name): APIRequest {
-            public typealias Response = Data
-            public var method: String { "\(method)" }
-            public var path: String { "\(path)" }
+        public struct \(op.operationId): APIRequest {
+            public typealias Body = \(bodyType)
+            public typealias Response = \(responseType)
+            public var method: String { \"\(method)\" }
+            public var path: String { \"\(path)\" }
+            public var body: Body?
+
+            public init(body: Body? = nil) {
+                self.body = body
+            }
         }
         """
-        try (output + "\n").write(to: dir.appendingPathComponent("\(name).swift"), atomically: true, encoding: .utf8)
+        try (output + "\n").write(to: dir.appendingPathComponent("\(op.operationId).swift"), atomically: true, encoding: .utf8)
     }
 }

--- a/Tests/GeneratorTests/Fixtures/Generated/Client/APIClient.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Client/APIClient.swift
@@ -9,16 +9,31 @@ extension URLSession: HTTPSession {}
 public struct APIClient {
     let baseURL: URL
     let session: HTTPSession
+    let defaultHeaders: [String: String]
 
-    public init(baseURL: URL, session: HTTPSession = URLSession.shared) {
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared, defaultHeaders: [String: String] = [:]) {
         self.baseURL = baseURL
         self.session = session
+        self.defaultHeaders = defaultHeaders
     }
 
     public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
         var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
         urlRequest.httpMethod = request.method
+        for (header, value) in defaultHeaders {
+            urlRequest.setValue(value, forHTTPHeaderField: header)
+        }
+        if let body = request.body {
+            urlRequest.httpBody = try JSONEncoder().encode(body)
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
         let (data, _) = try await session.data(for: urlRequest)
         return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+public extension APIClient {
+    init(baseURL: URL, bearerToken: String, session: HTTPSession = URLSession.shared) {
+        self.init(baseURL: baseURL, session: session, defaultHeaders: ["Authorization": "Bearer \(bearerToken)"])
     }
 }

--- a/Tests/GeneratorTests/Fixtures/Generated/Client/APIRequest.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Client/APIRequest.swift
@@ -1,7 +1,12 @@
 import Foundation
 
+/// Empty body type used for requests without a payload.
+public struct NoBody: Codable {}
+
 public protocol APIRequest {
+    associatedtype Body: Encodable = NoBody
     associatedtype Response: Decodable
     var method: String { get }
     var path: String { get }
+    var body: Body? { get }
 }

--- a/Tests/GeneratorTests/Fixtures/Generated/Client/Requests/GetTodos.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Client/Requests/GetTodos.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 public struct GetTodos: APIRequest {
+    public typealias Body = NoBody
     public typealias Response = Data
     public var method: String { "GET" }
     public var path: String { "/todos" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
 }


### PR DESCRIPTION
## Summary
- enhance `APIRequest` to include typed `Body` generics and optional `body` property
- extend `APIClient` to encode request bodies, decode typed responses, and support bearer token headers
- emit request structs using generics and provide initializers
- update golden fixtures for generator tests

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_686baeab7888832586de59f2c121c0eb