### PR TITLE
Add FoundationNetworking import to generated clients

### DIFF
--- a/Generated/Client/baseline-awareness/APIClient.swift
+++ b/Generated/Client/baseline-awareness/APIClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationNetworking
 
 public protocol HTTPSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)

--- a/Generated/Client/bootstrap/APIClient.swift
+++ b/Generated/Client/bootstrap/APIClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationNetworking
 
 public protocol HTTPSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)

--- a/Generated/Client/function-caller/APIClient.swift
+++ b/Generated/Client/function-caller/APIClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationNetworking
 
 public protocol HTTPSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)

--- a/Generated/Client/llm-gateway/APIClient.swift
+++ b/Generated/Client/llm-gateway/APIClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationNetworking
 
 public protocol HTTPSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)

--- a/Generated/Client/persist/APIClient.swift
+++ b/Generated/Client/persist/APIClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationNetworking
 
 public protocol HTTPSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)

--- a/Generated/Client/planner/APIClient.swift
+++ b/Generated/Client/planner/APIClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationNetworking
 
 public protocol HTTPSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)

--- a/Generated/Client/tools-factory/APIClient.swift
+++ b/Generated/Client/tools-factory/APIClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationNetworking
 
 public protocol HTTPSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)

--- a/Sources/ClientGenerator/ClientGenerator.swift
+++ b/Sources/ClientGenerator/ClientGenerator.swift
@@ -23,6 +23,7 @@ public enum ClientGenerator {
 
         let apiClient = """
         import Foundation
+        import FoundationNetworking
 
         public protocol HTTPSession {
             func data(for request: URLRequest) async throws -> (Data, URLResponse)

--- a/Tests/GeneratorTests/Fixtures/Generated/Client/APIClient.swift
+++ b/Tests/GeneratorTests/Fixtures/Generated/Client/APIClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationNetworking
 
 public protocol HTTPSession {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)


### PR DESCRIPTION
## Summary
- update API client generator to include `FoundationNetworking`
- patch generated API clients to match new generator output
- update golden fixture for APIClient

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_686bb45fab9483258153b8c39f129165