### PR TITLE
Add FountainAI service status reports

### DIFF
--- a/Reports/baseline-awareness-status.md
+++ b/Reports/baseline-awareness-status.md
@@ -1,0 +1,20 @@
+# Baseline Awareness Service – Implementation Status
+
+## Overview
+FountainAI Baseline Awareness manages baselines, drift, patterns, reflections and semantic analytics.
+Spec path: `FountainAi/openAPI/v1/baseline-awareness.yml` (version 1.0.0).
+
+## Implementation State
+- OpenAPI operations defined: 11
+- Generated client SDK at `Generated/Client/baseline-awareness`
+- Generated server kernel at `Generated/Server/baseline-awareness`
+- Server handlers are stubs returning empty `HTTPResponse` values
+- Client requests decode responses as raw `Data`
+- No dedicated tests for this service beyond generator fixtures
+
+## Next Steps toward Production
+- Expand OpenAPI parser to handle request/response schemas and parameters
+- Generate typed models so handlers and requests use concrete types
+- Implement real networking in the server runtime so the kernel can listen on a port
+- Add integration tests between the generated client and server
+- Provide container build instructions and runtime docs

--- a/Reports/bootstrap-status.md
+++ b/Reports/bootstrap-status.md
@@ -1,0 +1,19 @@
+# Bootstrap Service – Implementation Status
+
+## Overview
+The Bootstrap service initializes corpora, seeds GPT roles and adds baseline snapshots.
+Spec path: `FountainAi/openAPI/v1/bootstrap.yml` (version 1.0.0).
+
+## Implementation State
+- OpenAPI operations defined: 6
+- Generated client SDK at `Generated/Client/bootstrap`
+- Generated server kernel at `Generated/Server/bootstrap`
+- Server handlers are placeholders with no business logic
+- Client decodes all responses as `Data`
+- No Bootstrap-specific tests
+
+## Next Steps toward Production
+- Emit typed request/response models and populate handler parameters
+- Implement persistence interactions via the Awareness API
+- Integrate server networking and containerization scripts
+- Create tests verifying corpus initialization flows

--- a/Reports/function-caller-status.md
+++ b/Reports/function-caller-status.md
@@ -1,0 +1,19 @@
+# Function Caller Service – Implementation Status
+
+## Overview
+The Function Caller maps OpenAI function-calling plans to HTTP operations using definitions from the Tools Factory.
+Spec path: `FountainAi/openAPI/v1/function-caller.yml` (version 1.0.0).
+
+## Implementation State
+- OpenAPI operations defined: 3
+- Generated client SDK at `Generated/Client/function-caller`
+- Generated server kernel at `Generated/Server/function-caller`
+- Handler stubs perform no invocation logic
+- Client uses untyped `Data` decoding
+- No dedicated tests for this service
+
+## Next Steps toward Production
+- Implement dynamic function dispatch sourced from the Tools Factory
+- Generate typed models for request bodies and responses
+- Expand integration tests to cover registered tool execution
+- Add authentication and error handling

--- a/Reports/llm-gateway-status.md
+++ b/Reports/llm-gateway-status.md
@@ -1,0 +1,19 @@
+# LLM Gateway Service – Implementation Status
+
+## Overview
+The LLM Gateway proxies requests to any large language model with function-calling support.
+Spec path: `FountainAi/openAPI/v2/llm-gateway.yml` (version 2.0.0).
+
+## Implementation State
+- OpenAPI operations defined: 2
+- Generated client SDK at `Generated/Client/llm-gateway`
+- Generated server kernel at `Generated/Server/llm-gateway`
+- Networking layer is not implemented; server prints a startup message only
+- Client responses decoded as `Data`
+- No LLM Gateway-specific tests
+
+## Next Steps toward Production
+- Implement connection handling to underlying LLM APIs
+- Generate typed models for chat requests and responses
+- Add metrics endpoint integration and monitoring
+- Provide Docker build and deployment instructions

--- a/Reports/next-steps.md
+++ b/Reports/next-steps.md
@@ -1,0 +1,19 @@
+# Next Steps Toward Stable Production Release
+
+The individual status reports highlight that all FountainAI services share similar gaps:
+
+- Generated servers lack a real networking layer
+- Requests and responses use untyped `Data`
+- No service-specific integration tests exist
+- Persistence and external dependencies (Typesense, LLM APIs) are stubbed out
+
+To move the project toward a stable production release:
+
+1. **Extend the OpenAPI parser and generators** to emit typed models, parameters and response handling.
+2. **Implement a minimal HTTP runtime** so each generated server can listen on a port and process requests concurrently.
+3. **Wire service logic**: connect the Persistence service to Typesense, implement the Function Caller dispatch mechanism, and integrate the Planner with the LLM Gateway.
+4. **Create integration tests** that exercise each service via the generated client SDKs.
+5. **Add containerization scripts and deployment documentation** for running services in production.
+6. **Document versioning and changelog policies** to track API stability across the microservice suite.
+
+Following these steps will transition the FountainAI suite from generated stubs to fully functional, deployable microservices.

--- a/Reports/persistence-status.md
+++ b/Reports/persistence-status.md
@@ -1,0 +1,19 @@
+# Persistence Service – Implementation Status
+
+## Overview
+The Persistence service provides a Typesense-backed store for corpora, baselines, drifts and registered tools.
+Spec path: `FountainAi/openAPI/v1/persist.yml` (version 1.0.0).
+
+## Implementation State
+- OpenAPI operations defined: 8
+- Generated client SDK at `Generated/Client/persist`
+- Generated server kernel at `Generated/Server/persist`
+- Server does not yet integrate with Typesense
+- All responses are decoded as `Data` in the client
+- No persistence-specific tests exist
+
+## Next Steps toward Production
+- Implement database adapters and connection configuration
+- Emit typed models for persistence requests and responses
+- Add integration tests verifying CRUD operations
+- Provide containerization instructions for deploying with Typesense

--- a/Reports/planner-status.md
+++ b/Reports/planner-status.md
@@ -1,0 +1,19 @@
+# Planner Service – Implementation Status
+
+## Overview
+The Planner orchestrates LLM-driven workflows across the LLM Gateway and Function Caller.
+Spec path: `FountainAi/openAPI/v0/planner.yml` (version 0.1.0).
+
+## Implementation State
+- OpenAPI operations defined: 6
+- Generated client SDK at `Generated/Client/planner`
+- Generated server kernel at `Generated/Server/planner`
+- Router and handler stubs generated but not connected to an LLM
+- Client uses `Data` for all responses
+- No planner-specific test coverage
+
+## Next Steps toward Production
+- Upgrade API to stable v1 once semantics are finalized
+- Generate typed models for planning requests and results
+- Implement workflow orchestration calling LLM Gateway and Function Caller
+- Add end‑to‑end tests simulating planning sessions

--- a/Reports/tools-factory-status.md
+++ b/Reports/tools-factory-status.md
@@ -1,0 +1,19 @@
+# Tools Factory Service – Implementation Status
+
+## Overview
+The Tools Factory registers and manages tool definitions consumed by the Function Caller.
+Spec path: `FountainAi/openAPI/v1/tools-factory.yml` (version 1.0.0).
+
+## Implementation State
+- OpenAPI operations defined: 2
+- Generated client SDK at `Generated/Client/tools-factory`
+- Generated server kernel at `Generated/Server/tools-factory`
+- Server stubs do not persist tools yet
+- Client uses `Data` decoding for all endpoints
+- No dedicated tests
+
+## Next Steps toward Production
+- Implement storage to persist tool definitions in Typesense
+- Generate typed models for tool registration and listing
+- Add integration tests verifying function registration flow
+- Provide API authentication mechanisms


### PR DESCRIPTION
## Summary
- document implementation status for each FountainAI service in new `Reports/`
- outline next steps toward a stable production release

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_686bba54c1008325adf465b36b3ee1b9