### PR TITLE
Implement basic service wiring

### DIFF
--- a/Generated/Server/Shared/TypesenseClient.swift
+++ b/Generated/Server/Shared/TypesenseClient.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Minimal in-memory representation of a Typesense service used for testing.
+/// This allows the Persistence and Function Caller services to share state
+/// without requiring an external dependency.
+final class TypesenseClient {
+    static let shared = TypesenseClient()
+
+    private var corpora: Set<String> = []
+    private var functions: [String: Function] = [:]
+    private let lock = NSLock()
+
+    private init() {}
+
+    // MARK: - Corpora
+    func createCorpus(id: String) -> CorpusResponse {
+        lock.lock(); defer { lock.unlock() }
+        corpora.insert(id)
+        return CorpusResponse(corpusId: id, message: "created")
+    }
+
+    func listCorpora() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return Array(corpora)
+    }
+
+    // MARK: - Functions
+    func addFunction(_ fn: Function) {
+        lock.lock(); defer { lock.unlock() }
+        functions[fn.functionId] = fn
+    }
+
+    func listFunctions() -> [Function] {
+        lock.lock(); defer { lock.unlock() }
+        return Array(functions.values)
+    }
+
+    func functionDetails(id: String) -> Function? {
+        lock.lock(); defer { lock.unlock() }
+        return functions[id]
+    }
+}

--- a/Generated/Server/function-caller/Dispatcher.swift
+++ b/Generated/Server/function-caller/Dispatcher.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Dispatches registered functions by looking them up from the shared
+/// TypesenseClient and performing a simple URLSession call.
+struct FunctionDispatcher {
+    enum DispatchError: Error { case notFound }
+
+    let session: URLSession = .shared
+
+    func invoke(functionId: String, payload: Data) async throws -> Data {
+        guard let fn = TypesenseClient.shared.functionDetails(id: functionId) else {
+            throw DispatchError.notFound
+        }
+        guard let url = URL(string: fn.httpPath) else {
+            throw DispatchError.notFound
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = fn.httpMethod
+        req.httpBody = payload
+        let (data, _) = try await session.data(for: req)
+        return data
+    }
+}

--- a/Generated/Server/function-caller/Handlers.swift
+++ b/Generated/Server/function-caller/Handlers.swift
@@ -1,14 +1,34 @@
 import Foundation
 
+/// Implements the Function Caller dispatch mechanism. Registered functions are
+/// looked up from the shared TypesenseClient and invoked via URLSession.
 public struct Handlers {
+    let dispatcher = FunctionDispatcher()
+
     public init() {}
+
     public func getFunctionDetails(_ request: HTTPRequest) async throws -> HTTPResponse {
-        return HTTPResponse()
+        guard let id = request.path.split(separator: "/").last else {
+            return HTTPResponse(status: 404)
+        }
+        guard let fn = TypesenseClient.shared.functionDetails(id: String(id)) else {
+            return HTTPResponse(status: 404)
+        }
+        let data = try JSONEncoder().encode(fn)
+        return HTTPResponse(body: data)
     }
+
     public func listFunctions(_ request: HTTPRequest) async throws -> HTTPResponse {
-        return HTTPResponse()
+        let fns = TypesenseClient.shared.listFunctions()
+        let data = try JSONEncoder().encode(fns)
+        return HTTPResponse(body: data)
     }
+
     public func invokeFunction(_ request: HTTPRequest) async throws -> HTTPResponse {
-        return HTTPResponse()
+        guard let id = request.path.split(separator: "/").dropLast().last else {
+            return HTTPResponse(status: 404)
+        }
+        let result = try await dispatcher.invoke(functionId: String(id), payload: request.body)
+        return HTTPResponse(body: result)
     }
 }

--- a/Generated/Server/planner/Handlers.swift
+++ b/Generated/Server/planner/Handlers.swift
@@ -1,15 +1,27 @@
 import Foundation
 
+/// Planner handlers integrating with the LLM Gateway stub.
 public struct Handlers {
+    let llm = LLMGatewayClient()
+
     public init() {}
+
     public func plannerReason(_ request: HTTPRequest) async throws -> HTTPResponse {
-        return HTTPResponse()
+        guard let objective = try? JSONDecoder().decode(UserObjectiveRequest.self, from: request.body).objective else {
+            return HTTPResponse(status: 400)
+        }
+        let steps = try await llm.chat(objective: objective)
+        let data = try JSONEncoder().encode(PlanResponse(objective: objective, steps: steps))
+        return HTTPResponse(body: data)
     }
+
     public func getSemanticArc(_ request: HTTPRequest) async throws -> HTTPResponse {
         return HTTPResponse()
     }
     public func plannerListCorpora(_ request: HTTPRequest) async throws -> HTTPResponse {
-        return HTTPResponse()
+        let ids = TypesenseClient.shared.listCorpora()
+        let data = try JSONEncoder().encode(ids)
+        return HTTPResponse(body: data)
     }
     public func getReflectionHistory(_ request: HTTPRequest) async throws -> HTTPResponse {
         return HTTPResponse()

--- a/Generated/Server/planner/LLMGatewayClient.swift
+++ b/Generated/Server/planner/LLMGatewayClient.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Minimal client for the LLM Gateway. In this stub it simply echoes the
+/// objective to demonstrate integration without network dependencies.
+struct LLMGatewayClient {
+    func chat(objective: String) async throws -> String {
+        // In a real implementation this would POST to the LLM Gateway service.
+        return "Plan for: \(objective)"
+    }
+}


### PR DESCRIPTION
## Summary
- implement an in-memory `TypesenseClient` shared by services
- hook Persistence handlers to the Typesense stub
- add `FunctionDispatcher` and wire Function Caller handlers
- integrate Planner handlers with a minimal `LLMGatewayClient`
- tests continue to pass

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_686bc17586388325b21f9ab13d4623df