### PR TITLE
Fix FunctionCallerService build

### DIFF
--- a/Generated/Server/Shared/Models.swift
+++ b/Generated/Server/Shared/Models.swift
@@ -1,0 +1,12 @@
+public struct CorpusResponse: Codable, Sendable {
+    public let corpusId: String
+    public let message: String
+}
+
+public struct Function: Codable, Sendable {
+    public let description: String
+    public let functionId: String
+    public let httpMethod: String
+    public let httpPath: String
+    public let name: String
+}

--- a/Generated/Server/Shared/TypesenseClient.swift
+++ b/Generated/Server/Shared/TypesenseClient.swift
@@ -3,40 +3,34 @@ import Foundation
 /// Minimal in-memory representation of a Typesense service used for testing.
 /// This allows the Persistence and Function Caller services to share state
 /// without requiring an external dependency.
-final class TypesenseClient {
-    static let shared = TypesenseClient()
+public actor TypesenseClient {
+    public static let shared = TypesenseClient()
 
     private var corpora: Set<String> = []
     private var functions: [String: Function] = [:]
-    private let lock = NSLock()
 
     private init() {}
 
     // MARK: - Corpora
-    func createCorpus(id: String) -> CorpusResponse {
-        lock.lock(); defer { lock.unlock() }
+    public func createCorpus(id: String) -> CorpusResponse {
         corpora.insert(id)
         return CorpusResponse(corpusId: id, message: "created")
     }
 
-    func listCorpora() -> [String] {
-        lock.lock(); defer { lock.unlock() }
+    public func listCorpora() -> [String] {
         return Array(corpora)
     }
 
     // MARK: - Functions
-    func addFunction(_ fn: Function) {
-        lock.lock(); defer { lock.unlock() }
+    public func addFunction(_ fn: Function) {
         functions[fn.functionId] = fn
     }
 
-    func listFunctions() -> [Function] {
-        lock.lock(); defer { lock.unlock() }
+    public func listFunctions() -> [Function] {
         return Array(functions.values)
     }
 
-    func functionDetails(id: String) -> Function? {
-        lock.lock(); defer { lock.unlock() }
+    public func functionDetails(id: String) -> Function? {
         return functions[id]
     }
 }

--- a/Generated/Server/baseline-awareness/HTTPRequest.swift
+++ b/Generated/Server/baseline-awareness/HTTPRequest.swift
@@ -1,4 +1,15 @@
+import Foundation
+
 public struct HTTPRequest {
     public let method: String
     public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
 }

--- a/Generated/Server/bootstrap/HTTPRequest.swift
+++ b/Generated/Server/bootstrap/HTTPRequest.swift
@@ -1,4 +1,15 @@
+import Foundation
+
 public struct HTTPRequest {
     public let method: String
     public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
 }

--- a/Generated/Server/function-caller/Dispatcher.swift
+++ b/Generated/Server/function-caller/Dispatcher.swift
@@ -1,14 +1,14 @@
 import Foundation
+import FoundationNetworking
+import ServiceShared
 
 /// Dispatches registered functions by looking them up from the shared
 /// TypesenseClient and performing a simple URLSession call.
 struct FunctionDispatcher {
     enum DispatchError: Error { case notFound }
 
-    let session: URLSession = .shared
-
     func invoke(functionId: String, payload: Data) async throws -> Data {
-        guard let fn = TypesenseClient.shared.functionDetails(id: functionId) else {
+        guard let fn = await TypesenseClient.shared.functionDetails(id: functionId) else {
             throw DispatchError.notFound
         }
         guard let url = URL(string: fn.httpPath) else {
@@ -17,7 +17,7 @@ struct FunctionDispatcher {
         var req = URLRequest(url: url)
         req.httpMethod = fn.httpMethod
         req.httpBody = payload
-        let (data, _) = try await session.data(for: req)
+        let (data, _) = try await URLSession.shared.data(for: req)
         return data
     }
 }

--- a/Generated/Server/function-caller/HTTPRequest.swift
+++ b/Generated/Server/function-caller/HTTPRequest.swift
@@ -1,4 +1,15 @@
+import Foundation
+
 public struct HTTPRequest {
     public let method: String
     public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
 }

--- a/Generated/Server/function-caller/Handlers.swift
+++ b/Generated/Server/function-caller/Handlers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 /// Implements the Function Caller dispatch mechanism. Registered functions are
 /// looked up from the shared TypesenseClient and invoked via URLSession.
@@ -11,7 +12,7 @@ public struct Handlers {
         guard let id = request.path.split(separator: "/").last else {
             return HTTPResponse(status: 404)
         }
-        guard let fn = TypesenseClient.shared.functionDetails(id: String(id)) else {
+        guard let fn = await TypesenseClient.shared.functionDetails(id: String(id)) else {
             return HTTPResponse(status: 404)
         }
         let data = try JSONEncoder().encode(fn)
@@ -19,7 +20,7 @@ public struct Handlers {
     }
 
     public func listFunctions(_ request: HTTPRequest) async throws -> HTTPResponse {
-        let fns = TypesenseClient.shared.listFunctions()
+        let fns = await TypesenseClient.shared.listFunctions()
         let data = try JSONEncoder().encode(fns)
         return HTTPResponse(body: data)
     }

--- a/Generated/Server/llm-gateway/HTTPRequest.swift
+++ b/Generated/Server/llm-gateway/HTTPRequest.swift
@@ -1,4 +1,15 @@
+import Foundation
+
 public struct HTTPRequest {
     public let method: String
     public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
 }

--- a/Generated/Server/persist/HTTPRequest.swift
+++ b/Generated/Server/persist/HTTPRequest.swift
@@ -1,4 +1,15 @@
+import Foundation
+
 public struct HTTPRequest {
     public let method: String
     public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
 }

--- a/Generated/Server/persist/Handlers.swift
+++ b/Generated/Server/persist/Handlers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 /// Persistence handlers wired to an in-memory Typesense client. This mimics the
 /// real Typesense-backed service without requiring the dependency during tests.
@@ -19,7 +20,7 @@ public struct Handlers {
         return HTTPResponse()
     }
     public func listcorpora(_ request: HTTPRequest) async throws -> HTTPResponse {
-        let ids = typesense.listCorpora()
+        let ids = await typesense.listCorpora()
         let data = try JSONEncoder().encode(ids)
         return HTTPResponse(body: data)
     }
@@ -28,13 +29,13 @@ public struct Handlers {
         guard let model = try? JSONDecoder().decode(CorpusCreateRequest.self, from: request.body) else {
             return HTTPResponse(status: 400)
         }
-        let resp = typesense.createCorpus(id: model.corpusId)
+        let resp = await typesense.createCorpus(id: model.corpusId)
         let data = try JSONEncoder().encode(resp)
         return HTTPResponse(body: data)
     }
 
     public func listfunctions(_ request: HTTPRequest) async throws -> HTTPResponse {
-        let items = typesense.listFunctions()
+        let items = await typesense.listFunctions()
         let data = try JSONEncoder().encode(items)
         return HTTPResponse(body: data)
     }
@@ -43,7 +44,7 @@ public struct Handlers {
         guard let function = try? JSONDecoder().decode(Function.self, from: request.body) else {
             return HTTPResponse(status: 400)
         }
-        typesense.addFunction(function)
+        await typesense.addFunction(function)
         let resp = SuccessResponse(message: "stored")
         let data = try JSONEncoder().encode(resp)
         return HTTPResponse(body: data)
@@ -53,7 +54,7 @@ public struct Handlers {
         guard let id = request.path.split(separator: "/").last else {
             return HTTPResponse(status: 404)
         }
-        guard let fn = typesense.functionDetails(id: String(id)) else {
+        guard let fn = await typesense.functionDetails(id: String(id)) else {
             return HTTPResponse(status: 404)
         }
         let data = try JSONEncoder().encode(fn)

--- a/Generated/Server/planner/HTTPRequest.swift
+++ b/Generated/Server/planner/HTTPRequest.swift
@@ -1,4 +1,15 @@
+import Foundation
+
 public struct HTTPRequest {
     public let method: String
     public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
 }

--- a/Generated/Server/planner/Handlers.swift
+++ b/Generated/Server/planner/Handlers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 /// Planner handlers integrating with the LLM Gateway stub.
 public struct Handlers {
@@ -19,7 +20,7 @@ public struct Handlers {
         return HTTPResponse()
     }
     public func plannerListCorpora(_ request: HTTPRequest) async throws -> HTTPResponse {
-        let ids = TypesenseClient.shared.listCorpora()
+        let ids = await TypesenseClient.shared.listCorpora()
         let data = try JSONEncoder().encode(ids)
         return HTTPResponse(body: data)
     }

--- a/Generated/Server/tools-factory/HTTPRequest.swift
+++ b/Generated/Server/tools-factory/HTTPRequest.swift
@@ -1,4 +1,15 @@
+import Foundation
+
 public struct HTTPRequest {
     public let method: String
     public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,104 @@ let package = Package(
         .target(name: "ModelEmitter", dependencies: ["Parser"]),
         .target(name: "ClientGenerator", dependencies: ["Parser"]),
         .target(name: "ServerGenerator", dependencies: ["Parser"]),
+        .target(name: "ServiceShared", path: "Generated/Server/Shared"),
+        // Generated service modules used for integration testing
+        .target(
+            name: "BaselineAwarenessService",
+            path: "Generated/Server",
+            sources: [
+                "baseline-awareness/HTTPKernel.swift",
+                "baseline-awareness/Router.swift",
+                "baseline-awareness/Handlers.swift",
+                "baseline-awareness/Models.swift",
+                "baseline-awareness/HTTPRequest.swift",
+                "baseline-awareness/HTTPResponse.swift"
+            ]
+        ),
+        .target(name: "BaselineAwarenessClient", path: "Generated/Client/baseline-awareness"),
+        .target(
+            name: "BootstrapService",
+            path: "Generated/Server",
+            sources: [
+                "bootstrap/HTTPKernel.swift",
+                "bootstrap/Router.swift",
+                "bootstrap/Handlers.swift",
+                "bootstrap/Models.swift",
+                "bootstrap/HTTPRequest.swift",
+                "bootstrap/HTTPResponse.swift"
+            ]
+        ),
+        .target(name: "BootstrapClient", path: "Generated/Client/bootstrap"),
+        .target(
+            name: "PersistService",
+            dependencies: ["ServiceShared"],
+            path: "Generated/Server",
+            sources: [
+                "persist/HTTPKernel.swift",
+                "persist/Router.swift",
+                "persist/Handlers.swift",
+                "persist/Models.swift",
+                "persist/HTTPRequest.swift",
+                "persist/HTTPResponse.swift"
+            ]
+        ),
+        .target(name: "PersistClient", path: "Generated/Client/persist"),
+        .target(
+            name: "FunctionCallerService",
+            dependencies: ["ServiceShared"],
+            path: "Generated/Server",
+            sources: [
+                "function-caller/HTTPKernel.swift",
+                "function-caller/Router.swift",
+                "function-caller/Handlers.swift",
+                "function-caller/Models.swift",
+                "function-caller/Dispatcher.swift",
+                "function-caller/HTTPRequest.swift",
+                "function-caller/HTTPResponse.swift"
+            ]
+        ),
+        .target(name: "FunctionCallerClient", path: "Generated/Client/function-caller"),
+        .target(
+            name: "PlannerService",
+            dependencies: ["ServiceShared"],
+            path: "Generated/Server",
+            sources: [
+                "planner/HTTPKernel.swift",
+                "planner/Router.swift",
+                "planner/Handlers.swift",
+                "planner/Models.swift",
+                "planner/LLMGatewayClient.swift",
+                "planner/HTTPRequest.swift",
+                "planner/HTTPResponse.swift"
+            ]
+        ),
+        .target(name: "PlannerClient", path: "Generated/Client/planner"),
+        .target(
+            name: "ToolsFactoryService",
+            path: "Generated/Server",
+            sources: [
+                "tools-factory/HTTPKernel.swift",
+                "tools-factory/Router.swift",
+                "tools-factory/Handlers.swift",
+                "tools-factory/Models.swift",
+                "tools-factory/HTTPRequest.swift",
+                "tools-factory/HTTPResponse.swift"
+            ]
+        ),
+        .target(name: "ToolsFactoryClient", path: "Generated/Client/tools-factory"),
+        .target(
+            name: "LLMGatewayService",
+            path: "Generated/Server",
+            sources: [
+                "llm-gateway/HTTPKernel.swift",
+                "llm-gateway/Router.swift",
+                "llm-gateway/Handlers.swift",
+                "llm-gateway/Models.swift",
+                "llm-gateway/HTTPRequest.swift",
+                "llm-gateway/HTTPResponse.swift"
+            ]
+        ),
+        .target(name: "LLMGatewayClientSDK", path: "Generated/Client/llm-gateway"),
         .target(
             name: "IntegrationRuntime",
             dependencies: [
@@ -47,7 +145,16 @@ let package = Package(
         ),
         .testTarget(
             name: "IntegrationTests",
-            dependencies: ["IntegrationRuntime"],
+            dependencies: [
+                "IntegrationRuntime",
+                "BaselineAwarenessService", "BaselineAwarenessClient",
+                "BootstrapService", "BootstrapClient",
+                "PersistService", "PersistClient",
+                "FunctionCallerService", "FunctionCallerClient",
+                "PlannerService", "PlannerClient",
+                "ToolsFactoryService", "ToolsFactoryClient",
+                "LLMGatewayService", "LLMGatewayClientSDK"
+            ],
             resources: []
         )
     ]

--- a/Tests/IntegrationTests/APIClient+Raw.swift
+++ b/Tests/IntegrationTests/APIClient+Raw.swift
@@ -1,0 +1,72 @@
+import Foundation
+@testable import BaselineAwarenessClient
+@testable import BootstrapClient
+@testable import PersistClient
+@testable import FunctionCallerClient
+@testable import PlannerClient
+@testable import ToolsFactoryClient
+@testable import LLMGatewayClientSDK
+
+// Convenience helpers to bypass JSON decoding for simple tests
+extension BaselineAwarenessClient.APIClient {
+    func sendRaw<R: BaselineAwarenessClient.APIRequest>(_ request: R) async throws -> Data {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return data
+    }
+}
+
+extension BootstrapClient.APIClient {
+    func sendRaw<R: BootstrapClient.APIRequest>(_ request: R) async throws -> Data {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return data
+    }
+}
+
+extension PersistClient.APIClient {
+    func sendRaw<R: PersistClient.APIRequest>(_ request: R) async throws -> Data {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return data
+    }
+}
+
+extension FunctionCallerClient.APIClient {
+    func sendRaw<R: FunctionCallerClient.APIRequest>(_ request: R) async throws -> Data {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return data
+    }
+}
+
+extension PlannerClient.APIClient {
+    func sendRaw<R: PlannerClient.APIRequest>(_ request: R) async throws -> Data {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return data
+    }
+}
+
+extension ToolsFactoryClient.APIClient {
+    func sendRaw<R: ToolsFactoryClient.APIRequest>(_ request: R) async throws -> Data {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return data
+    }
+}
+
+extension LLMGatewayClientSDK.APIClient {
+    func sendRaw<R: LLMGatewayClientSDK.APIRequest>(_ request: R) async throws -> Data {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return data
+    }
+}

--- a/Tests/IntegrationTests/ServicesIntegrationTests.swift
+++ b/Tests/IntegrationTests/ServicesIntegrationTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+import IntegrationRuntime
+import NIOHTTP1
+
+@testable import BaselineAwarenessService
+@testable import BaselineAwarenessClient
+@testable import BootstrapService
+@testable import BootstrapClient
+@testable import PersistService
+@testable import PersistClient
+@testable import FunctionCallerService
+@testable import FunctionCallerClient
+@testable import PlannerService
+@testable import PlannerClient
+@testable import ToolsFactoryService
+@testable import ToolsFactoryClient
+@testable import LLMGatewayService
+@testable import LLMGatewayClientSDK
+
+final class ServicesIntegrationTests: XCTestCase {
+    func startServer(with kernel: IntegrationRuntime.HTTPKernel) async throws -> (NIOHTTPServer, Int) {
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+        return (server, port)
+    }
+
+    func testBaselineAwarenessHealth() async throws {
+        let serviceKernel = BaselineAwarenessService.HTTPKernel()
+        let kernel = IntegrationRuntime.HTTPKernel { req in
+            let sreq = BaselineAwarenessService.HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
+            let sresp = try await serviceKernel.handle(sreq)
+            return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
+        }
+        let (server, port) = try await startServer(with: kernel)
+        defer { try? await server.stop() }
+
+        let client = BaselineAwarenessClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
+        let data = try await client.sendRaw(BaselineAwarenessClient.health_health_get())
+        XCTAssertEqual(data.count, 0)
+    }
+
+    func testBootstrapSeedRoles() async throws {
+        let serviceKernel = BootstrapService.HTTPKernel()
+        let kernel = IntegrationRuntime.HTTPKernel { req in
+            let sreq = BootstrapService.HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
+            let sresp = try await serviceKernel.handle(sreq)
+            return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
+        }
+        let (server, port) = try await startServer(with: kernel)
+        defer { try? await server.stop() }
+
+        let client = BootstrapClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
+        let data = try await client.sendRaw(BootstrapClient.seedRoles())
+        XCTAssertEqual(data.count, 0)
+    }
+
+    func testPersistListCorpora() async throws {
+        _ = await PersistService.TypesenseClient.shared.createCorpus(id: "c1")
+        let serviceKernel = PersistService.HTTPKernel()
+        let kernel = IntegrationRuntime.HTTPKernel { req in
+            let sreq = PersistService.HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
+            let sresp = try await serviceKernel.handle(sreq)
+            return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
+        }
+        let (server, port) = try await startServer(with: kernel)
+        defer { try? await server.stop() }
+
+        let client = PersistClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
+        let data = try await client.sendRaw(PersistClient.listCorpora())
+        let ids = try JSONDecoder().decode([String].self, from: data)
+        XCTAssertEqual(ids, ["c1"])
+    }
+
+    func testFunctionCallerListFunctions() async throws {
+        let fn = FunctionCallerService.Function(description: "test", function_id: "f1", http_method: "GET", http_path: "http://example.com", name: "fn", parameters_schema: "{}")
+        await FunctionCallerService.TypesenseClient.shared.addFunction(fn)
+        let serviceKernel = FunctionCallerService.HTTPKernel()
+        let kernel = IntegrationRuntime.HTTPKernel { req in
+            let sreq = FunctionCallerService.HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
+            let sresp = try await serviceKernel.handle(sreq)
+            return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
+        }
+        let (server, port) = try await startServer(with: kernel)
+        defer { try? await server.stop() }
+
+        let client = FunctionCallerClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
+        let data = try await client.sendRaw(FunctionCallerClient.list_functions())
+        let items = try JSONDecoder().decode([FunctionCallerClient.FunctionInfo].self, from: data)
+        XCTAssertEqual(items.first?.function_id, "f1")
+    }
+
+    func testPlannerListCorpora() async throws {
+        _ = await PlannerService.TypesenseClient.shared.createCorpus(id: "p1")
+        let serviceKernel = PlannerService.HTTPKernel()
+        let kernel = IntegrationRuntime.HTTPKernel { req in
+            let sreq = PlannerService.HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
+            let sresp = try await serviceKernel.handle(sreq)
+            return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
+        }
+        let (server, port) = try await startServer(with: kernel)
+        defer { try? await server.stop() }
+
+        let client = PlannerClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
+        let data = try await client.sendRaw(PlannerClient.planner_list_corpora())
+        let ids = try JSONDecoder().decode([String].self, from: data)
+        XCTAssertEqual(ids, ["p1"])
+    }
+
+    func testToolsFactoryListTools() async throws {
+        let serviceKernel = ToolsFactoryService.HTTPKernel()
+        let kernel = IntegrationRuntime.HTTPKernel { req in
+            let sreq = ToolsFactoryService.HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
+            let sresp = try await serviceKernel.handle(sreq)
+            return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
+        }
+        let (server, port) = try await startServer(with: kernel)
+        defer { try? await server.stop() }
+
+        let client = ToolsFactoryClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
+        let data = try await client.sendRaw(ToolsFactoryClient.list_tools())
+        XCTAssertEqual(data.count, 0)
+    }
+
+    func testLLMGatewayMetrics() async throws {
+        let serviceKernel = LLMGatewayService.HTTPKernel()
+        let kernel = IntegrationRuntime.HTTPKernel { req in
+            let sreq = LLMGatewayService.HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
+            let sresp = try await serviceKernel.handle(sreq)
+            return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
+        }
+        let (server, port) = try await startServer(with: kernel)
+        defer { try? await server.stop() }
+
+        let client = LLMGatewayClientSDK.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
+        let data = try await client.sendRaw(LLMGatewayClientSDK.metrics_metrics_get())
+        XCTAssertEqual(data.count, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- make TypesenseClient an actor and public
- mark shared models sendable
- add headers and body to generated service requests
- update service handlers and integration tests for async actor access
- import FoundationNetworking for URLSession usage

## Testing
- `swift build --target FunctionCallerService` (succeeds)
- `swift test -v` *(build succeeds, verbose output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_686bcc421bc08325adf572db49da21e7