### PR TITLE
Add Docker Compose and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ docker run --rm baseline-awareness
 The container simply starts the Swift binary and prints a message. Networking is
 not yet implemented.
 
+### Docker Compose
+To build and run all services together:
+```bash
+docker-compose build
+docker-compose up
+```
+
+
 ---
 
 ## 📜 License

--- a/Reports/deployment.md
+++ b/Reports/deployment.md
@@ -1,0 +1,35 @@
+# Production Deployment Guide
+
+This document explains how to build and run all FountainAI services using Docker Compose.
+
+Each generated server already contains a `Dockerfile`. The root `docker-compose.yml` composes these images so they can be started together.
+
+## Building the Containers
+
+Run the following command at the repository root:
+
+```bash
+docker-compose build
+```
+
+This compiles each service into a minimal Swift container.
+
+## Starting the Services
+
+To start all containers:
+
+```bash
+docker-compose up
+```
+
+The services currently print a startup message. Networking and persistent storage are not yet implemented.
+
+## Stopping and Removing Containers
+
+Press `Ctrl+C` to stop the running services, then remove containers with:
+
+```bash
+docker-compose down
+```
+
+This workflow prepares the project for a production environment once networking and persistence layers are added.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+services:
+  baseline-awareness:
+    build: ./Generated/Server/baseline-awareness
+  bootstrap:
+    build: ./Generated/Server/bootstrap
+  function-caller:
+    build: ./Generated/Server/function-caller
+  llm-gateway:
+    build: ./Generated/Server/llm-gateway
+  planner:
+    build: ./Generated/Server/planner
+  persist:
+    build: ./Generated/Server/persist
+  tools-factory:
+    build: ./Generated/Server/tools-factory


### PR DESCRIPTION
## Summary
- add docker-compose.yml to build containers for each service
- document deployment steps via Docker Compose
- mention Docker Compose in the README service containers section

## Testing
- `swift test -v` *(fails: command exceeded environment limits)*


------
https://chatgpt.com/codex/tasks/task_e_686bd24b858c83259f3170eb15a1edeb