### PR TITLE
Add versioning and changelog docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-07-07
+### Added
+- Initial OpenAPI specs and generator skeleton.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ To build and run all services together:
 docker-compose build
 docker-compose up
 ```
+## 🗓 Versioning & Changelog
+The service specifications follow Semantic Versioning. Major API revisions live in directories like `FountainAi/openAPI/v1`. All changes are recorded in [CHANGELOG.md](CHANGELOG.md); see [VERSIONING.md](VERSIONING.md) for policy details.
+
 
 
 ---

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,10 @@
+# Versioning Policy
+
+FountainAI services and the OpenAPI generator follow [Semantic Versioning](https://semver.org/).
+
+- **API directories** under `FountainAi/openAPI/v<major>/` indicate the public **major** version.
+- Breaking API changes create a new `v<major>` directory.
+- Within a major version, backwards‑compatible additions bump the **minor** version.
+- Bug fixes and documentation updates bump the **patch** version.
+
+Every change to an API spec or the generator must be recorded in `CHANGELOG.md` with the corresponding version number.


### PR DESCRIPTION
## Summary
- document Semantic Versioning approach and changelog requirements
- add initial CHANGELOG with 0.1.0 entry
- mention policy in README

## Testing
- `swift test -v` *(failed: build exceeded log limits)*

------
https://chatgpt.com/codex/tasks/task_e_686bd500d6d48325ac95fc0761bc2d38