### PR TITLE
Implement baseline health check

### DIFF
--- a/Docs/StatusQuo/Reports/baseline-awareness-status.md
+++ b/Docs/StatusQuo/Reports/baseline-awareness-status.md
@@ -9,7 +9,7 @@ Spec path: `FountainAi/openAPI/v1/baseline-awareness.yml` (version 1.0.0).
 - Generated client SDK at `Generated/Client/baseline-awareness` now encodes request bodies and decodes typed responses
 - Generated server kernel at `Generated/Server/baseline-awareness` includes a minimal socket‑based runtime and typed model definitions
 - Router decodes JSON bodies into models and forwards them to typed handler methods
-- Handler implementations still return empty `HTTPResponse` objects and perform no persistence or analysis
+- `GET /health` now returns a structured JSON status while other handlers remain stubs
 - A Dockerfile is provided and build/run instructions are included in the repository README
 - No dedicated tests exercise this service beyond generator fixtures
 

--- a/Generated/Server/baseline-awareness/Handlers.swift
+++ b/Generated/Server/baseline-awareness/Handlers.swift
@@ -24,7 +24,8 @@ public struct Handlers {
         return HTTPResponse()
     }
     public func healthHealthGet(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        let json = try JSONEncoder().encode(["status": "ok"])
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: json)
     }
     public func listreflections(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse()


### PR DESCRIPTION
## Summary
- implement JSON response for GET /health in baseline awareness handler
- update baseline awareness status report

## Testing
- `swift test -v` *(fails: build warnings then aborted)*


------
https://chatgpt.com/codex/tasks/task_e_686be0b6487483259b3c81f3f1919576