### PR TITLE
Enhance baseline awareness server runtime

### DIFF
--- a/Docs/StatusQuo/Reports/baseline-awareness-status.md
+++ b/Docs/StatusQuo/Reports/baseline-awareness-status.md
@@ -7,14 +7,12 @@ Spec path: `FountainAi/openAPI/v1/baseline-awareness.yml` (version 1.0.0).
 ## Implementation State
 - OpenAPI operations defined: **11** covering corpus initialization, baseline and drift ingestion, pattern storage, reflection management and analytics queries
 - Generated client SDK at `Generated/Client/baseline-awareness` now encodes request bodies and decodes typed responses
-- Generated server kernel at `Generated/Server/baseline-awareness` includes a minimal socket‑based runtime and typed model definitions
+- Generated server kernel at `Generated/Server/baseline-awareness` now includes `main.swift` with a simple socket runtime that parses headers and bodies
 - Router decodes JSON bodies into models and forwards them to typed handler methods
-- `GET /health` now returns a structured JSON status while other handlers remain stubs
-- A Dockerfile is provided and build/run instructions are included in the repository README
-- No dedicated tests exercise this service beyond generator fixtures
+- `GET /health` returns a structured JSON status while other handlers remain stubs
+- A `Dockerfile` builds the service binary, and build/run instructions appear in the repository README
+- New integration test verifies the `/health` endpoint using the generated client
 
 ## Next Steps toward Production
-- Enhance the runtime to decode request bodies, extract parameters and return structured JSON
 - Add persistence adapters and real analytics logic
-- Provide integration tests exercising the generated client against the server
-- Document how to build and run the service including the provided Dockerfile
+- Expand documentation on building and running the service container

--- a/Generated/Server/baseline-awareness/Dockerfile
+++ b/Generated/Server/baseline-awareness/Dockerfile
@@ -1,0 +1,9 @@
+# baseline-awareness server container
+FROM swift:6.1-jammy AS build
+WORKDIR /src
+COPY ./ .
+RUN swiftc -O HTTPKernel.swift HTTPRequest.swift HTTPResponse.swift Router.swift Handlers.swift Models.swift main.swift -o /server
+
+FROM ubuntu:22.04
+COPY --from=build /server /server
+CMD ["/server"]

--- a/Generated/Server/baseline-awareness/main.swift
+++ b/Generated/Server/baseline-awareness/main.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Dispatch
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+final class SimpleHTTPRuntime {
+    enum RuntimeError: Error { case socket, bind, listen }
+    let kernel: HTTPKernel
+    let port: Int32
+    private var serverFD: Int32 = -1
+
+    init(kernel: HTTPKernel, port: Int32 = 8080) {
+        self.kernel = kernel
+        self.port = port
+    }
+
+    func start() throws {
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        guard serverFD >= 0 else { throw RuntimeError.socket }
+        var opt: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: in_addr_t(0))
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                bind(serverFD, ptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult >= 0 else { throw RuntimeError.bind }
+        guard listen(serverFD, 16) >= 0 else { throw RuntimeError.listen }
+        DispatchQueue.global().async { [weak self] in self?.acceptLoop() }
+    }
+
+    private func acceptLoop() {
+        while true {
+            var addr = sockaddr()
+            var len: socklen_t = socklen_t(MemoryLayout<sockaddr>.size)
+            let fd = accept(serverFD, &addr, &len)
+            if fd >= 0 {
+                DispatchQueue.global().async {
+                    self.handle(fd: fd)
+                }
+            }
+        }
+    }
+
+    private func handle(fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { close(fd); return }
+        let data = Data(buffer[0..<n])
+        guard let request = parseRequest(data) else { close(fd); return }
+        Task {
+            let resp = try await kernel.handle(request)
+            let respData = serialize(resp)
+            respData.withUnsafeBytes { _ = write(fd, $0.baseAddress!, respData.count) }
+            close(fd)
+        }
+    }
+
+    private func parseRequest(_ data: Data) -> HTTPRequest? {
+        guard let headerRange = data.range(of: Data("\r\n\r\n".utf8)) else { return nil }
+        let headerData = data[..<headerRange.lowerBound]
+        let bodyData = data[headerRange.upperBound...]
+        guard let headerString = String(data: headerData, encoding: .utf8) else { return nil }
+        let headerLines = headerString.split(separator: "\r\n")
+        guard let requestLine = headerLines.first else { return nil }
+        let tokens = requestLine.split(separator: " ")
+        guard tokens.count >= 2 else { return nil }
+        let method = String(tokens[0])
+        let path = String(tokens[1])
+        var headers: [String: String] = [:]
+        for line in headerLines.dropFirst() {
+            let parts = line.split(separator: ":", maxSplits: 1)
+            if parts.count == 2 {
+                let name = parts[0].trimmingCharacters(in: .whitespaces)
+                let value = parts[1].trimmingCharacters(in: .whitespaces)
+                headers[String(name)] = String(value)
+            }
+        }
+        return HTTPRequest(method: method, path: path, headers: headers, body: Data(bodyData))
+    }
+
+    private func serialize(_ resp: HTTPResponse) -> Data {
+        var text = "HTTP/1.1 \(resp.status) OK\r\n"
+        for (k, v) in resp.headers { text += "\(k): \(v)\r\n" }
+        text += "Content-Length: \(resp.body.count)\r\n"
+        text += "\r\n"
+        var data = Data(text.utf8)
+        data.append(resp.body)
+        return data
+    }
+}
+
+let kernel = HTTPKernel()
+
+do {
+    let runtime = SimpleHTTPRuntime(kernel: kernel, port: 8080)
+    try runtime.start()
+    print("baseline-awareness server listening on port 8080")
+    dispatchMain()
+} catch {
+    print("Failed to start server: \(error)")
+}

--- a/Tests/IntegrationTests/ServicesIntegrationTests.swift
+++ b/Tests/IntegrationTests/ServicesIntegrationTests.swift
@@ -36,7 +36,8 @@ final class ServicesIntegrationTests: XCTestCase {
 
         let client = BaselineAwarenessClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
         let data = try await client.sendRaw(BaselineAwarenessClient.health_health_get())
-        XCTAssertEqual(data.count, 0)
+        let status = try JSONDecoder().decode([String: String].self, from: data)
+        XCTAssertEqual(status["status"], "ok")
     }
 
     func testBootstrapSeedRoles() async throws {


### PR DESCRIPTION
## Summary
- add a `Dockerfile` and runtime entry point for the baseline awareness service
- parse headers and body in the baseline awareness simple runtime
- test the `/health` endpoint with the generated client
- update the baseline awareness status report

## Testing
- `swift test -v` *(fails: build requires lengthy dependency compilation and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_686be2e7fc2883258d991bf4a8ad3d48