### PR TITLE
Integrate baseline store with persistence service

### DIFF
--- a/Generated/Server/Shared/Models.swift
+++ b/Generated/Server/Shared/Models.swift
@@ -10,3 +10,28 @@ public struct Function: Codable, Sendable {
     public let httpPath: String
     public let name: String
 }
+
+public struct Baseline: Codable, Sendable {
+    public let baselineId: String
+    public let content: String
+    public let corpusId: String
+}
+
+public struct Drift: Codable, Sendable {
+    public let content: String
+    public let corpusId: String
+    public let driftId: String
+}
+
+public struct Patterns: Codable, Sendable {
+    public let content: String
+    public let corpusId: String
+    public let patternsId: String
+}
+
+public struct Reflection: Codable, Sendable {
+    public let content: String
+    public let corpusId: String
+    public let question: String
+    public let reflectionId: String
+}

--- a/Generated/Server/Shared/TypesenseClient.swift
+++ b/Generated/Server/Shared/TypesenseClient.swift
@@ -8,6 +8,10 @@ public actor TypesenseClient {
 
     private var corpora: Set<String> = []
     private var functions: [String: Function] = [:]
+    private var baselines: [String: [String: Baseline]] = [:]
+    private var drifts: [String: [String: Drift]] = [:]
+    private var patterns: [String: [String: Patterns]] = [:]
+    private var reflections: [String: [String: Reflection]] = [:]
 
     private init() {}
 
@@ -32,5 +36,42 @@ public actor TypesenseClient {
 
     public func functionDetails(id: String) -> Function? {
         return functions[id]
+    }
+
+    // MARK: - Baseline Data
+    public func addBaseline(_ baseline: Baseline) {
+        var items = baselines[baseline.corpusId] ?? [:]
+        items[baseline.baselineId] = baseline
+        baselines[baseline.corpusId] = items
+    }
+
+    public func addDrift(_ drift: Drift) {
+        var items = drifts[drift.corpusId] ?? [:]
+        items[drift.driftId] = drift
+        drifts[drift.corpusId] = items
+    }
+
+    public func addPatterns(_ patternsReq: Patterns) {
+        var items = patterns[patternsReq.corpusId] ?? [:]
+        items[patternsReq.patternsId] = patternsReq
+        patterns[patternsReq.corpusId] = items
+    }
+
+    public func addReflection(_ reflection: Reflection) {
+        var items = reflections[reflection.corpusId] ?? [:]
+        items[reflection.reflectionId] = reflection
+        reflections[reflection.corpusId] = items
+    }
+
+    public func reflectionCount(for corpusId: String) -> Int {
+        return reflections[corpusId]?.count ?? 0
+    }
+
+    public func historyCount(for corpusId: String) -> Int {
+        let b = baselines[corpusId]?.count ?? 0
+        let d = drifts[corpusId]?.count ?? 0
+        let p = patterns[corpusId]?.count ?? 0
+        let r = reflections[corpusId]?.count ?? 0
+        return b + d + p + r
     }
 }

--- a/Generated/Server/baseline-awareness/BaselineStore.swift
+++ b/Generated/Server/baseline-awareness/BaselineStore.swift
@@ -1,61 +1,51 @@
 import Foundation
+import ServiceShared
 
 /// In-memory store used by the Baseline Awareness service during tests.
 public actor BaselineStore {
     public static let shared = BaselineStore()
 
-    struct Corpus {
-        var baselines: [String: String] = [:]
-        var drifts: [String: String] = [:]
-        var patterns: [String: String] = [:]
-        var reflections: [String: ReflectionRequest] = [:]
+    private let typesense: TypesenseClient
+
+    private init(typesense: TypesenseClient = .shared) {
+        self.typesense = typesense
     }
 
-    private var corpora: [String: Corpus] = [:]
-    private init() {}
-
     // MARK: - Corpus Management
-    public func createCorpus(id: String) -> InitOut {
-        if corpora[id] == nil {
-            corpora[id] = Corpus()
-        }
+    public func createCorpus(id: String) async -> InitOut {
+        _ = await typesense.createCorpus(id: id)
         return InitOut(message: "created")
     }
 
     // MARK: - Baseline Data
-    public func addBaseline(_ baseline: BaselineRequest) {
-        var corpus = corpora[baseline.corpusId] ?? Corpus()
-        corpus.baselines[baseline.baselineId] = baseline.content
-        corpora[baseline.corpusId] = corpus
+    public func addBaseline(_ baseline: BaselineRequest) async {
+        let item = Baseline(baselineId: baseline.baselineId, content: baseline.content, corpusId: baseline.corpusId)
+        await typesense.addBaseline(item)
     }
 
-    public func addDrift(_ drift: DriftRequest) {
-        var corpus = corpora[drift.corpusId] ?? Corpus()
-        corpus.drifts[drift.driftId] = drift.content
-        corpora[drift.corpusId] = corpus
+    public func addDrift(_ drift: DriftRequest) async {
+        let item = Drift(content: drift.content, corpusId: drift.corpusId, driftId: drift.driftId)
+        await typesense.addDrift(item)
     }
 
-    public func addPatterns(_ patternsReq: PatternsRequest) {
-        var corpus = corpora[patternsReq.corpusId] ?? Corpus()
-        corpus.patterns[patternsReq.patternsId] = patternsReq.content
-        corpora[patternsReq.corpusId] = corpus
+    public func addPatterns(_ patternsReq: PatternsRequest) async {
+        let item = Patterns(content: patternsReq.content, corpusId: patternsReq.corpusId, patternsId: patternsReq.patternsId)
+        await typesense.addPatterns(item)
     }
 
-    public func addReflection(_ reflection: ReflectionRequest) {
-        var corpus = corpora[reflection.corpusId] ?? Corpus()
-        corpus.reflections[reflection.reflectionId] = reflection
-        corpora[reflection.corpusId] = corpus
+    public func addReflection(_ reflection: ReflectionRequest) async {
+        let item = Reflection(content: reflection.content, corpusId: reflection.corpusId, question: reflection.question, reflectionId: reflection.reflectionId)
+        await typesense.addReflection(item)
     }
 
     // MARK: - Query
-    public func reflectionSummary(for corpusId: String) -> ReflectionSummaryResponse {
-        let count = corpora[corpusId]?.reflections.count ?? 0
+    public func reflectionSummary(for corpusId: String) async -> ReflectionSummaryResponse {
+        let count = await typesense.reflectionCount(for: corpusId)
         return ReflectionSummaryResponse(message: "\(count) reflections")
     }
 
-    public func historySummary(for corpusId: String) -> HistorySummaryResponse {
-        let corpus = corpora[corpusId] ?? Corpus()
-        let count = corpus.baselines.count + corpus.drifts.count + corpus.patterns.count + corpus.reflections.count
+    public func historySummary(for corpusId: String) async -> HistorySummaryResponse {
+        let count = await typesense.historyCount(for: corpusId)
         return HistorySummaryResponse(summary: "items: \(count)")
     }
 }

--- a/Generated/Server/persist/Handlers.swift
+++ b/Generated/Server/persist/Handlers.swift
@@ -11,13 +11,32 @@ public struct Handlers {
         self.typesense = typesense
     }
     public func addbaseline(_ request: HTTPRequest) async throws -> HTTPResponse {
-        return HTTPResponse()
+        guard let corpusId = request.path.split(separator: "/").dropFirst(2).first,
+              let model = try? JSONDecoder().decode(Baseline.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        await typesense.addBaseline(model)
+        let data = try JSONEncoder().encode(SuccessResponse(message: "stored"))
+        return HTTPResponse(body: data)
     }
+
     public func listreflections(_ request: HTTPRequest) async throws -> HTTPResponse {
-        return HTTPResponse()
+        guard let corpusId = request.path.split(separator: "/").dropFirst(2).first else {
+            return HTTPResponse(status: 400)
+        }
+        let count = await typesense.reflectionCount(for: String(corpusId))
+        let data = try JSONEncoder().encode(["count": count])
+        return HTTPResponse(body: data)
     }
+
     public func addreflection(_ request: HTTPRequest) async throws -> HTTPResponse {
-        return HTTPResponse()
+        guard let corpusId = request.path.split(separator: "/").dropFirst(2).first,
+              let reflection = try? JSONDecoder().decode(Reflection.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        await typesense.addReflection(reflection)
+        let data = try JSONEncoder().encode(SuccessResponse(message: "stored"))
+        return HTTPResponse(body: data)
     }
     public func listcorpora(_ request: HTTPRequest) async throws -> HTTPResponse {
         let ids = await typesense.listCorpora()

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         // Generated service modules used for integration testing
         .target(
             name: "BaselineAwarenessService",
+            dependencies: ["ServiceShared"],
             path: "Generated/Server",
             sources: [
                 "baseline-awareness/HTTPKernel.swift",
@@ -30,7 +31,8 @@ let package = Package(
                 "baseline-awareness/Handlers.swift",
                 "baseline-awareness/Models.swift",
                 "baseline-awareness/HTTPRequest.swift",
-                "baseline-awareness/HTTPResponse.swift"
+                "baseline-awareness/HTTPResponse.swift",
+                "baseline-awareness/BaselineStore.swift"
             ]
         ),
         .target(name: "BaselineAwarenessClient", path: "Generated/Client/baseline-awareness"),


### PR DESCRIPTION
## Summary
- add shared baseline models and extend TypesenseClient for baseline, drift, pattern and reflection storage
- refactor BaselineStore to use TypesenseClient for persistence
- implement persistence handlers for baseline and reflection endpoints
- wire BaselineAwarenessService to ServiceShared in Package manifest

## Testing
- `swift test -v` *(fails: type 'URLSession' does not conform to protocol 'HTTPSession')*

------
https://chatgpt.com/codex/tasks/task_e_686bea1bdcf083258133d88abaf7a5e5