### PR TITLE
Implement Prometheus metrics adapter

### DIFF
--- a/Generated/Server/Shared/PrometheusAdapter.swift
+++ b/Generated/Server/Shared/PrometheusAdapter.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public actor PrometheusAdapter {
+    public static let shared = PrometheusAdapter()
+
+    private var counters: [String:Int] = [:]
+
+    public init() {}
+
+    private func key(service: String, path: String) -> String {
+        "requests_total{service=\"\(service)\",path=\"\(path)\"}"
+    }
+
+    public func record(service: String, path: String) {
+        let k = key(service: service, path: path)
+        counters[k, default: 0] += 1
+    }
+
+    public func exposition() -> String {
+        let lines = counters.map { "\($0.key) \($0.value)" }.sorted().joined(separator: "\n")
+        return lines + "\n"
+    }
+}

--- a/Generated/Server/baseline-awareness/HTTPKernel.swift
+++ b/Generated/Server/baseline-awareness/HTTPKernel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct HTTPKernel {
     let router: Router
@@ -8,6 +9,8 @@ public struct HTTPKernel {
     }
 
     public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
-        try await router.route(request)
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "baseline-awareness", path: request.path)
+        return resp
     }
 }

--- a/Generated/Server/baseline-awareness/Router.swift
+++ b/Generated/Server/baseline-awareness/Router.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct Router {
     public var handlers: Handlers
@@ -33,6 +34,9 @@ public struct Router {
         case ("GET", "/health"):
             let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
             return try await handlers.healthHealthGet(request, body: body)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
         case ("GET", "/corpus/reflections/{corpus_id}"):
             let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
             return try await handlers.listreflections(request, body: body)

--- a/Generated/Server/bootstrap/HTTPKernel.swift
+++ b/Generated/Server/bootstrap/HTTPKernel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct HTTPKernel {
     let router: Router
@@ -8,6 +9,8 @@ public struct HTTPKernel {
     }
 
     public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
-        try await router.route(request)
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "bootstrap", path: request.path)
+        return resp
     }
 }

--- a/Generated/Server/bootstrap/Router.swift
+++ b/Generated/Server/bootstrap/Router.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct Router {
     public var handlers: Handlers
@@ -21,6 +22,9 @@ public struct Router {
             return try await handlers.seedroles(request)
         case ("POST", "/bootstrap/baseline"):
             return try await handlers.bootstrapaddbaseline(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
         default:
             return HTTPResponse(status: 404)
         }

--- a/Generated/Server/function-caller/HTTPKernel.swift
+++ b/Generated/Server/function-caller/HTTPKernel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct HTTPKernel {
     let router: Router
@@ -8,6 +9,8 @@ public struct HTTPKernel {
     }
 
     public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
-        try await router.route(request)
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "function-caller", path: request.path)
+        return resp
     }
 }

--- a/Generated/Server/function-caller/Router.swift
+++ b/Generated/Server/function-caller/Router.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct Router {
     public var handlers: Handlers
@@ -15,6 +16,9 @@ public struct Router {
             return try await handlers.listFunctions(request)
         case ("POST", "/functions/{function_id}/invoke"):
             return try await handlers.invokeFunction(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
         default:
             return HTTPResponse(status: 404)
         }

--- a/Generated/Server/llm-gateway/HTTPKernel.swift
+++ b/Generated/Server/llm-gateway/HTTPKernel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct HTTPKernel {
     let router: Router
@@ -8,6 +9,8 @@ public struct HTTPKernel {
     }
 
     public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
-        try await router.route(request)
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "llm-gateway", path: request.path)
+        return resp
     }
 }

--- a/Generated/Server/llm-gateway/Handlers.swift
+++ b/Generated/Server/llm-gateway/Handlers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct Handlers {
     public init() {}
@@ -6,6 +7,7 @@ public struct Handlers {
         return HTTPResponse()
     }
     public func metricsMetricsGet(_ request: HTTPRequest) async throws -> HTTPResponse {
-        return HTTPResponse()
+        let text = PrometheusAdapter.shared.exposition()
+        return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
     }
 }

--- a/Generated/Server/llm-gateway/Router.swift
+++ b/Generated/Server/llm-gateway/Router.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct Router {
     public var handlers: Handlers

--- a/Generated/Server/persist/HTTPKernel.swift
+++ b/Generated/Server/persist/HTTPKernel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct HTTPKernel {
     let router: Router
@@ -8,6 +9,8 @@ public struct HTTPKernel {
     }
 
     public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
-        try await router.route(request)
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "persist", path: request.path)
+        return resp
     }
 }

--- a/Generated/Server/persist/Router.swift
+++ b/Generated/Server/persist/Router.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct Router {
     public var handlers: Handlers
@@ -25,6 +26,9 @@ public struct Router {
             return try await handlers.addfunction(request)
         case ("GET", "/functions/{functionId}"):
             return try await handlers.getfunctiondetails(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
         default:
             return HTTPResponse(status: 404)
         }

--- a/Generated/Server/planner/HTTPKernel.swift
+++ b/Generated/Server/planner/HTTPKernel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct HTTPKernel {
     let router: Router
@@ -8,6 +9,8 @@ public struct HTTPKernel {
     }
 
     public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
-        try await router.route(request)
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "planner", path: request.path)
+        return resp
     }
 }

--- a/Generated/Server/planner/Router.swift
+++ b/Generated/Server/planner/Router.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct Router {
     public var handlers: Handlers
@@ -21,6 +22,9 @@ public struct Router {
             return try await handlers.plannerExecute(request)
         case ("POST", "/planner/reflections/"):
             return try await handlers.postReflection(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
         default:
             return HTTPResponse(status: 404)
         }

--- a/Generated/Server/tools-factory/HTTPKernel.swift
+++ b/Generated/Server/tools-factory/HTTPKernel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct HTTPKernel {
     let router: Router
@@ -8,6 +9,8 @@ public struct HTTPKernel {
     }
 
     public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
-        try await router.route(request)
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "tools-factory", path: request.path)
+        return resp
     }
 }

--- a/Generated/Server/tools-factory/Router.swift
+++ b/Generated/Server/tools-factory/Router.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceShared
 
 public struct Router {
     public var handlers: Handlers
@@ -13,6 +14,9 @@ public struct Router {
             return try await handlers.registerOpenapi(request)
         case ("GET", "/tools"):
             return try await handlers.listTools(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
         default:
             return HTTPResponse(status: 404)
         }

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
         .target(name: "BaselineAwarenessClient", path: "Generated/Client/baseline-awareness"),
         .target(
             name: "BootstrapService",
+            dependencies: ["ServiceShared"],
             path: "Generated/Server",
             sources: [
                 "bootstrap/HTTPKernel.swift",
@@ -95,6 +96,7 @@ let package = Package(
         .target(name: "PlannerClient", path: "Generated/Client/planner"),
         .target(
             name: "ToolsFactoryService",
+            dependencies: ["ServiceShared"],
             path: "Generated/Server",
             sources: [
                 "tools-factory/HTTPKernel.swift",
@@ -108,6 +110,7 @@ let package = Package(
         .target(name: "ToolsFactoryClient", path: "Generated/Client/tools-factory"),
         .target(
             name: "LLMGatewayService",
+            dependencies: ["ServiceShared"],
             path: "Generated/Server",
             sources: [
                 "llm-gateway/HTTPKernel.swift",


### PR DESCRIPTION
## Summary
- add `PrometheusAdapter` actor in shared server code
- expose `/metrics` endpoint across services
- record per-path request counters using the new adapter
- link Bootstrap, ToolsFactory and LLMGateway services with `ServiceShared`

## Testing
- `swift test -v` *(fails: environment limits prevented completion)*

------
https://chatgpt.com/codex/tasks/task_e_686c074140348325a2ae5f30bc3eef03