### PR TITLE
Implement baseline awareness doc updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: swift-actions/setup-swift@v1

--- a/Docs/StatusQuo/Reports/baseline-awareness-status.md
+++ b/Docs/StatusQuo/Reports/baseline-awareness-status.md
@@ -13,8 +13,8 @@ Spec path: `FountainAi/openAPI/v1/baseline-awareness.yml` (version 1.0.0).
 - A `Dockerfile` builds the service binary, and build/run instructions appear in the repository README
 - New integration tests now cover corpus initialization and baseline ingestion in addition to the `/health` endpoint
 - The `BaselineStore` now persists via `TypesenseClient`, sharing the persistence service infrastructure
+- Expanded documentation describes building and running the service container and verifying `/health`
+- CI workflow runs integration tests on both Linux and macOS using `AsyncHTTPClient` and the NIO server
 
 ## Next Steps toward Production
 - Implement production analytics logic on top of the new persistence layer
-- Expand documentation on building and running the service container
-- Ensure integration tests run on both Linux and macOS using AsyncHTTPClient and the NIO server

--- a/Docs/StatusQuo/Reports/deployment.md
+++ b/Docs/StatusQuo/Reports/deployment.md
@@ -33,6 +33,12 @@ docker build -f Generated/Server/baseline-awareness/Dockerfile -t baseline-aware
 docker run -p 8080:8080 baseline-awareness
 ```
 
+After the container starts, verify the health endpoint:
+
+```bash
+curl http://localhost:8080/health
+```
+
 ## Stopping and Removing Containers
 
 Press `Ctrl+C` to stop the running services, then remove containers with:

--- a/README.md
+++ b/README.md
@@ -115,16 +115,22 @@ every push and pull request using Swift 6.
 
 Each generated server directory contains a `Dockerfile` that compiles the stub
 server into a minimal container. To build and run the `baseline-awareness`
-service:
+service and expose it on port **8080**:
 
 ```bash
 cd Generated/Server/baseline-awareness
 docker build -t baseline-awareness .
-docker run --rm baseline-awareness
+docker run --rm -p 8080:8080 baseline-awareness
 ```
 
-The container simply starts the Swift binary and prints a message. Networking is
-not yet implemented.
+Once running, verify the service is alive:
+
+```bash
+curl http://localhost:8080/health
+```
+
+The container starts the Swift service and responds on `http://localhost:8080`.
+See [deployment.md](Docs/StatusQuo/Reports/deployment.md) for more details.
 
 ### Docker Compose
 To build and run all services together:


### PR DESCRIPTION
## Summary
- document port 8080 and health check for the baseline-awareness container
- update deployment docs with curl health check
- update baseline status notes with docs and CI improvements
- run CI on both Linux and macOS

## Testing
- `swift test -v` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686c0afbb4488325a5714f76c1ba66e3