### PR TITLE
Fix docs location in structure tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ swift-codex-openapi-kernel/
 ├── Tests/
 │   ├── GeneratorTests/
 │   └── ServerTests/
-├── codex-plan.md
+├── Docs/
+│   ├── Historical/               ← Past plans and design documents
+│   └── StatusQuo/                ← Current status reports
 ├── README.md
 └── .codex
 ```


### PR DESCRIPTION
## Summary
- fix README repo structure tree to reference Docs/

## Testing
- `swift test -v` *(fails: compilation runs indefinitely)*

------
https://chatgpt.com/codex/tasks/task_e_686c21143e98832588289f7709c424e3