### PR TITLE
Address async defer errors in tests

### DIFF
--- a/.codex
+++ b/.codex
@@ -9,5 +9,5 @@
     "tests": "Tests"
   },
   "cli": "swift run generator --input OpenAPI/api.yaml --output Generated/",
-  "test": "swift test -v"
+  "test": "./run-tests.sh"
 }

--- a/Sources/IntegrationRuntime/AsyncHTTPClientDriver.swift
+++ b/Sources/IntegrationRuntime/AsyncHTTPClientDriver.swift
@@ -2,7 +2,7 @@ import AsyncHTTPClient
 import NIOCore
 import NIOHTTP1
 
-public final class AsyncHTTPClientDriver: HTTPClientProtocol {
+public final class AsyncHTTPClientDriver: HTTPClientProtocol, @unchecked Sendable {
     let client: HTTPClient
 
     public init(eventLoopGroupProvider: HTTPClient.EventLoopGroupProvider = .createNew) {

--- a/Sources/IntegrationRuntime/NIOHTTPServer.swift
+++ b/Sources/IntegrationRuntime/NIOHTTPServer.swift
@@ -2,7 +2,7 @@
 @preconcurrency import NIOHTTP1
 import Foundation
 
-public final class NIOHTTPServer {
+public final class NIOHTTPServer: @unchecked Sendable {
     let kernel: HTTPKernel
     let group: EventLoopGroup
     var channel: Channel?

--- a/Tests/IntegrationTests/APIClient+Raw.swift
+++ b/Tests/IntegrationTests/APIClient+Raw.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FoundationNetworking
 @testable import BaselineAwarenessClient
 @testable import BootstrapClient
 @testable import PersistClient

--- a/Tests/IntegrationTests/Handlers.swift
+++ b/Tests/IntegrationTests/Handlers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import IntegrationRuntime
 
 public struct Handlers {
     public init() {}

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -10,10 +10,10 @@ final class IntegrationTests: XCTestCase {
         }
         let server = NIOHTTPServer(kernel: kernel)
         let port = try await server.start(port: 0)
-        defer { try? await server.stop() }
+        addTeardownBlock { try? await server.stop() }
 
         let client = AsyncHTTPClientDriver()
-        defer { try? await client.shutdown() }
+        addTeardownBlock { try? await client.shutdown() }
 
         let (buffer, _) = try await client.execute(method: .GET, url: "http://127.0.0.1:\(port)/todos", headers: HTTPHeaders(), body: nil)
         XCTAssertEqual(buffer.readableBytes, 0)

--- a/Tests/IntegrationTests/Router.swift
+++ b/Tests/IntegrationTests/Router.swift
@@ -1,4 +1,5 @@
 import Foundation
+import IntegrationRuntime
 
 public struct Router {
     public var handlers: Handlers

--- a/Tests/IntegrationTests/ServicesIntegrationTests.swift
+++ b/Tests/IntegrationTests/ServicesIntegrationTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import IntegrationRuntime
 import NIOHTTP1
+import ServiceShared
 
 @testable import BaselineAwarenessService
 @testable import BaselineAwarenessClient
@@ -32,7 +33,7 @@ final class ServicesIntegrationTests: XCTestCase {
             return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
         }
         let (server, port) = try await startServer(with: kernel)
-        defer { try? await server.stop() }
+        addTeardownBlock { try? await server.stop() }
 
         let client = BaselineAwarenessClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
         let data = try await client.sendRaw(BaselineAwarenessClient.health_health_get())
@@ -48,7 +49,7 @@ final class ServicesIntegrationTests: XCTestCase {
             return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
         }
         let (server, port) = try await startServer(with: kernel)
-        defer { try? await server.stop() }
+        addTeardownBlock { try? await server.stop() }
 
         let client = BaselineAwarenessClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
         let initBody = BaselineAwarenessClient.InitIn(corpusId: "c1")
@@ -67,7 +68,7 @@ final class ServicesIntegrationTests: XCTestCase {
             return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
         }
         let (server, port) = try await startServer(with: kernel)
-        defer { try? await server.stop() }
+        addTeardownBlock { try? await server.stop() }
 
         let client = BootstrapClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
         let data = try await client.sendRaw(BootstrapClient.seedRoles())
@@ -75,7 +76,7 @@ final class ServicesIntegrationTests: XCTestCase {
     }
 
     func testPersistListCorpora() async throws {
-        _ = await PersistService.TypesenseClient.shared.createCorpus(id: "c1")
+        _ = await TypesenseClient.shared.createCorpus(id: "c1")
         let serviceKernel = PersistService.HTTPKernel()
         let kernel = IntegrationRuntime.HTTPKernel { req in
             let sreq = PersistService.HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
@@ -83,7 +84,7 @@ final class ServicesIntegrationTests: XCTestCase {
             return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
         }
         let (server, port) = try await startServer(with: kernel)
-        defer { try? await server.stop() }
+        addTeardownBlock { try? await server.stop() }
 
         let client = PersistClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
         let data = try await client.sendRaw(PersistClient.listCorpora())
@@ -92,8 +93,9 @@ final class ServicesIntegrationTests: XCTestCase {
     }
 
     func testFunctionCallerListFunctions() async throws {
-        let fn = FunctionCallerService.Function(description: "test", function_id: "f1", http_method: "GET", http_path: "http://example.com", name: "fn", parameters_schema: "{}")
-        await FunctionCallerService.TypesenseClient.shared.addFunction(fn)
+        let json = #"{"description":"test","functionId":"f1","httpMethod":"GET","httpPath":"http://example.com","name":"fn"}"#.data(using: .utf8)!
+        let fn = try JSONDecoder().decode(ServiceShared.Function.self, from: json)
+        await TypesenseClient.shared.addFunction(fn)
         let serviceKernel = FunctionCallerService.HTTPKernel()
         let kernel = IntegrationRuntime.HTTPKernel { req in
             let sreq = FunctionCallerService.HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
@@ -101,7 +103,7 @@ final class ServicesIntegrationTests: XCTestCase {
             return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
         }
         let (server, port) = try await startServer(with: kernel)
-        defer { try? await server.stop() }
+        addTeardownBlock { try? await server.stop() }
 
         let client = FunctionCallerClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
         let data = try await client.sendRaw(FunctionCallerClient.list_functions())
@@ -110,7 +112,7 @@ final class ServicesIntegrationTests: XCTestCase {
     }
 
     func testPlannerListCorpora() async throws {
-        _ = await PlannerService.TypesenseClient.shared.createCorpus(id: "p1")
+        _ = await TypesenseClient.shared.createCorpus(id: "p1")
         let serviceKernel = PlannerService.HTTPKernel()
         let kernel = IntegrationRuntime.HTTPKernel { req in
             let sreq = PlannerService.HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
@@ -118,7 +120,7 @@ final class ServicesIntegrationTests: XCTestCase {
             return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
         }
         let (server, port) = try await startServer(with: kernel)
-        defer { try? await server.stop() }
+        addTeardownBlock { try? await server.stop() }
 
         let client = PlannerClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
         let data = try await client.sendRaw(PlannerClient.planner_list_corpora())
@@ -134,7 +136,7 @@ final class ServicesIntegrationTests: XCTestCase {
             return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
         }
         let (server, port) = try await startServer(with: kernel)
-        defer { try? await server.stop() }
+        addTeardownBlock { try? await server.stop() }
 
         let client = ToolsFactoryClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
         let data = try await client.sendRaw(ToolsFactoryClient.list_tools())
@@ -149,7 +151,7 @@ final class ServicesIntegrationTests: XCTestCase {
             return IntegrationRuntime.HTTPResponse(status: sresp.status, body: sresp.body)
         }
         let (server, port) = try await startServer(with: kernel)
-        defer { try? await server.stop() }
+        addTeardownBlock { try? await server.stop() }
 
         let client = LLMGatewayClientSDK.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
         let data = try await client.sendRaw(LLMGatewayClientSDK.metrics_metrics_get())

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Wraps `swift test -v` to limit line lengths for Codex
+swift test -v 2>&1 | fold -sw 160


### PR DESCRIPTION
## Summary
- mark server and client classes as `@unchecked Sendable`
- update integration tests to use `addTeardownBlock` and reference `ServiceShared` models
- fix missing imports in helper test files
- wrap Typesense function setup using JSON decode

## Testing
- `swift test -v` *(0 tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_686c24b6ba3483258031b54422ff7490